### PR TITLE
Last split

### DIFF
--- a/src/settings.py
+++ b/src/settings.py
@@ -54,6 +54,9 @@ USER_MANUAL_URL = "https://pilgrimtabby.github.io/pilgrim-autosplitter/"
 # Create or access the QSettings file that persists user settings
 settings = QSettings("pilgrim_tabby", "Pilgrim Autosplitter")
 
+# The default number of loops per split
+DEFAULT_LOOP_COUNT = 1
+
 # The max amount of loops and wait time (in seconds) permitted for split images
 MAX_LOOPS_AND_WAIT = 99999
 
@@ -156,9 +159,6 @@ def set_defaults() -> None:
 
         # The default delay (seconds) before a split
         set_value("DEFAULT_DELAY", 0.0)
-
-        # The default number of loops per split
-        set_value("DEFAULT_LOOP_COUNT", 0)
 
         # The default pause (seconds) after a split
         set_value("DEFAULT_PAUSE", 1.0)

--- a/src/settings.py
+++ b/src/settings.py
@@ -43,7 +43,7 @@ COMPARISON_FRAME_WIDTH = 320
 COMPARISON_FRAME_HEIGHT = 240
 
 # Pilgrim Autosplitter's current version number
-VERSION_NUMBER = "v1.0.3"
+VERSION_NUMBER = "v1.0.4"
 
 # The URL of Pilgrim Autosplitter's GitHub repo
 REPO_URL = "https://github.com/pilgrimtabby/pilgrim-autosplitter/"

--- a/src/settings.py
+++ b/src/settings.py
@@ -164,7 +164,7 @@ def set_defaults() -> None:
         set_value("DEFAULT_PAUSE", 1.0)
 
         # The FPS used by splitter and ui_controller
-        set_value("FPS", 60)
+        set_value("FPS", 30)
 
         # The location of split images
         set_value("LAST_IMAGE_DIR", "")

--- a/src/splitter/split_dir.py
+++ b/src/splitter/split_dir.py
@@ -64,10 +64,6 @@ class SplitDir:
             exists.
         current_loop (int): The current split image's current loop, if it
             exists.
-        ignore_split_request (bool): A flag that is set exclusively by splitter
-            in the event of a normal split. See splitter's documentation for
-            details, but the idea is to stop splitter and ui_controller from
-            both calling next_split_image for the same split.
         list (list[_SplitImage]): A list of all split images in
             settings.get_str("LAST_IMAGE_DIR").
     """
@@ -90,16 +86,7 @@ class SplitDir:
     ##################
 
     def next_split_image(self) -> None:
-        """Go to the next split image or next loop (whichever is next).
-
-        If splitter has set ignore_split_request to True, unset the flag and
-        return without doing anything. This is to prevent a double split (see
-        splitter._set_normal_split_action).
-        """
-        if self.ignore_split_request:
-            self.ignore_split_request = False
-            return
-
+        """Go to the next split image or next loop (whichever is next)."""
         if self.current_loop == self.list[self.current_image_index].loops:
             if self.current_image_index < len(self.list) - 1:
                 self.current_image_index += 1

--- a/src/splitter/split_dir.py
+++ b/src/splitter/split_dir.py
@@ -26,8 +26,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-"""Store and manipulate split images.
-"""
+"""Store and manipulate split images."""
 
 
 import glob
@@ -47,6 +46,7 @@ import settings
 from settings import (
     COMPARISON_FRAME_HEIGHT,
     COMPARISON_FRAME_WIDTH,
+    DEFAULT_LOOP_COUNT,
     MAX_LOOPS_AND_WAIT,
     MAX_THRESHOLD,
 )
@@ -73,7 +73,7 @@ class SplitDir:
         self.list = self._get_split_images()
         if len(self.list) > 0:
             self.current_image_index = 0
-            self.current_loop = 0
+            self.current_loop = 1
         else:
             self.current_image_index = None
             self.current_loop = None
@@ -89,16 +89,16 @@ class SplitDir:
         if self.current_loop == self.list[self.current_image_index].loops:
             if self.current_image_index < len(self.list) - 1:
                 self.current_image_index += 1
-                self.current_loop = 0
+                self.current_loop = 1
 
         else:
             self.current_loop += 1
 
     def previous_split_image(self) -> None:
-        """Go to the previous split image or, if current_loop > 0, to the
+        """Go to the previous split image or, if current_loop > 1, to the
         previous loop.
         """
-        if self.current_loop == 0:
+        if self.current_loop == 1:
             if self.current_image_index > 0:
                 self.current_image_index -= 1
                 self.current_loop = self.list[self.current_image_index].loops
@@ -116,7 +116,7 @@ class SplitDir:
         else:
             self.list = new_list
             self.current_image_index = 0
-            self.current_loop = 0
+            self.current_loop = 1
 
     def set_default_threshold(self) -> None:
         """Update threshold in each SplitImage whose threshold is default."""
@@ -531,7 +531,9 @@ class SplitDir:
             delay = re.search(r"_\#(.+?)\#", self.name)
             if delay is None or not str(delay[1]).replace(".", "", 1).isdigit():
                 return settings.get_float("DEFAULT_DELAY"), True
-            return min(float(delay[1]), MAX_LOOPS_AND_WAIT), False
+
+            delay = float(delay[1])
+            return min(delay, MAX_LOOPS_AND_WAIT), False
 
         def _get_pause_from_name(self) -> float:
             """Set split image's pause duration after split by reading filename
@@ -555,7 +557,9 @@ class SplitDir:
             pause = re.search(r"_\[(.+?)\]", self.name)
             if pause is None or not str(pause[1]).replace(".", "", 1).isdigit():
                 return settings.get_float("DEFAULT_PAUSE"), True
-            return max(min(float(pause[1]), MAX_LOOPS_AND_WAIT), 1), False
+
+            pause = float(pause[1])
+            return max(min(pause, MAX_LOOPS_AND_WAIT), 1), False
 
         def _get_threshold_from_name(self) -> float:
             """Set split image's threshold match percent by reading filename
@@ -575,16 +579,22 @@ class SplitDir:
             threshold = re.search(r"_\((.+?)\)", self.name)
             if threshold is None or not str(threshold[1]).replace(".", "", 1).isdigit():
                 return settings.get_float("DEFAULT_THRESHOLD"), True
-            return min(float(threshold[1]) / 100, MAX_THRESHOLD), False
+
+            threshold = float(threshold[1])
+            return min(threshold / 100, MAX_THRESHOLD), False
 
         def _get_loops_from_name(self) -> int:
             """Set split image's loop count by reading filename flags.
 
             Loop amount is set in the filename by placing an integer between
-            two @s, like this: _@4@_ (the image loops 4 extra times)
+            two @s, like this: _@4@_ (the image is used 4 times instead of 1)
 
             Using is_digit guarantees that this method will not return negative
             numbers, which is what we want.
+
+            The loops can never be fewer than 1, which is the reason for the
+            complicated last line of this method. The semantic meaning is: make
+            sure the loops are below MAX_LOOPS_AND_WAIT and not less than 1.
 
             Returns:
                 int: The number of loops indicated in the filename, or the
@@ -592,5 +602,7 @@ class SplitDir:
             """
             loops = re.search(r"_\@(.+?)\@", self.name)
             if loops is None or not loops[1].isdigit():
-                return settings.get_int("DEFAULT_LOOP_COUNT"), True
-            return min(int(loops[1]), MAX_LOOPS_AND_WAIT), False
+                return DEFAULT_LOOP_COUNT, True
+
+            loops = int(loops[1])
+            return max(min(loops, MAX_LOOPS_AND_WAIT), 1), False

--- a/src/splitter/split_dir.py
+++ b/src/splitter/split_dir.py
@@ -64,14 +64,13 @@ class SplitDir:
             exists.
         current_loop (int): The current split image's current loop, if it
             exists.
-        list (list[_SplitImage]): A list of all split images in
+        list (list[_SplitImage]): A list of all split images in the directory
             settings.get_str("LAST_IMAGE_DIR").
     """
 
     def __init__(self):
         """Initialize a list of SplitImage objects and set flags accordingly."""
         self.list = self._get_split_images()
-        self.ignore_split_request = False
         if len(self.list) > 0:
             self.current_image_index = 0
             self.current_loop = 0

--- a/src/splitter/splitter.py
+++ b/src/splitter/splitter.py
@@ -65,7 +65,7 @@ class Splitter:
             self.splits to go to a new split image.
         comparison_frame (numpy.ndarray): Numpy array used to generate a
             comparison with a split image.
-        current_match_percent (float): The most recent match percent between a
+        match_percent (float): The most recent match percent between a
             frame and a split image.
         delay_remaining (float): The amount of time left (in seconds) until a
             planned split occurs.
@@ -74,7 +74,7 @@ class Splitter:
         dummy_split_action (bool): When True, tells ui_controller to perform a
             dummy split action.
         frame_pixmap (QPixmap): QPixmap used to show video feed on UI.
-        highest_match_percent (float): The highest match percent so far between
+        highest_percent (float): The highest match percent so far between
             a frame and a split image.
         normal_split_action (bool): When True, tells ui_controller to perform a
             normal split action.
@@ -109,8 +109,8 @@ class Splitter:
 
         # _compare_thread
         self.splits = SplitDir()
-        self.current_match_percent = None
-        self.highest_match_percent = None
+        self.match_percent = None
+        self.highest_percent = None
         self.delaying = False
         self.delay_remaining = None
         self.suspended = True
@@ -379,19 +379,19 @@ class Splitter:
         The following flags are used to determine when to return a value:
             match_found: False until one of two conditions is met--
                 1) The split image's below_flag is False, and
-                    current_match_percent >= threshold_match_percent
-                2) went_above_threshold_flag is True and current_match_percent
-                    < threshold_match_percent
+                    match_percent >= threshold_percent
+                2) went_above_threshold_flag is True and match_percent
+                    < threshold_percent
             went_above_threshold_flag: False until the split image's below_flag
-                is True, and current_match_percent >= threshold_match_percent
+                is True, and match_percent >= threshold_percent
 
         Returns:
             bool: True if one of the two above match_found conditions are met.
                 False if self._compare_thread_finished is called, terminating
                 the thread.
         """
-        self.current_match_percent = 0
-        self.highest_match_percent = 0
+        self.match_percent = 0
+        self.highest_percent = 0
         match_found = False
         went_above_threshold_flag = False
         frames_this_second = 0
@@ -422,12 +422,12 @@ class Splitter:
                 continue
 
             # Check image against template image
-            self.current_match_percent = self._get_match_percent(frame)
-            if self.current_match_percent > self.highest_match_percent:
-                self.highest_match_percent = self.current_match_percent
+            self.match_percent = self._get_match_percent(frame)
+            if self.match_percent > self.highest_percent:
+                self.highest_percent = self.match_percent
 
             if (
-                self.current_match_percent
+                self.match_percent
                 >= self.splits.list[self.splits.current_image_index].threshold
             ):
                 if self.splits.list[self.splits.current_image_index].below_flag:
@@ -441,8 +441,8 @@ class Splitter:
                 break
 
         # Setting these to None tells the ui_controller the splitter is down
-        self.current_match_percent = None
-        self.highest_match_percent = None
+        self.match_percent = None
+        self.highest_percent = None
         return match_found
 
     def _update_fps_factor(

--- a/src/splitter/splitter.py
+++ b/src/splitter/splitter.py
@@ -222,23 +222,26 @@ class Splitter:
     def _open_capture(self) -> cv2.VideoCapture:
         """Open and configure a cv2 VideoCapture.
 
-        Sets CAP_PROP_BUFFERSIZE to 1 to reduce stuttering.
-        Sets CAP_PROP_FRAME_WIDTH and CAP_PROP_FRAME_HEIGHT to their respective
-        values because these appear to be the smallest available values. The
-        smaller the capture's width and height, the fast images can be
-        downscaled, and the less CPU is required to do so.
-        Sets self._capture_max_fps to the capture's maximum FPS on platforms
+        Set CAP_PROP_BUFFERSIZE to 1 to reduce stuttering.
+
+        Set CAP_PROP_FRAME_WIDTH and CAP_PROP_FRAME_HEIGHT to our target value.
+        I can't imagine any capture cards actually support this, but this
+        forces the capture source to choose the next-closest value, which in
+        some cases is quite a lot smaller than the default. This saves CPU.
+
+        Set self._capture_max_fps to the capture's maximum FPS on platforms
         where this is supported. This is done to prevent unnecessary
         comparisons from being generated in _compare due to a mismatch between
         the user's selected framerate and a capture-imposed cap which is lower.
+        This also saves CPU.
 
         Returns:
             cv2.VideoCapture: The initialized and configured VideoCapture.
         """
         cap = cv2.VideoCapture(settings.get_int("LAST_CAPTURE_SOURCE_INDEX"))
         cap.set(cv2.CAP_PROP_BUFFERSIZE, 1)
-        cap.set(cv2.CAP_PROP_FRAME_WIDTH, 640)
-        cap.set(cv2.CAP_PROP_FRAME_HEIGHT, 480)
+        cap.set(cv2.CAP_PROP_FRAME_WIDTH, COMPARISON_FRAME_WIDTH)
+        cap.set(cv2.CAP_PROP_FRAME_HEIGHT, COMPARISON_FRAME_HEIGHT)
         try:
             self._capture_max_fps = cap.get(cv2.CAP_PROP_FPS)
         except cv2.error:

--- a/src/splitter/splitter.py
+++ b/src/splitter/splitter.py
@@ -546,8 +546,12 @@ class Splitter:
         The various flags set by this method are read by ui_controller, which
         references them to update the UI and send hotkey presses.
         """
-        # Save now so we can use the old image's delay_duration
-        split_image = self.splits.list[self.splits.current_image_index]
+        # Save now so we can execute the delay_duration block correctly
+        # The split will have already changed, but we rely on these values
+        # to execute that block so we need to save them now
+        loop = self.splits.current_loop
+        index = self.splits.current_image_index
+        split_image = self.splits.list[index]
 
         # Handle delay
         if split_image.delay_duration > 0:
@@ -584,8 +588,12 @@ class Splitter:
         else:
             self.normal_split_action = True
 
-        # Handle post-split pause
-        if split_image.pause_duration > 0:
+        # Don't delay after very last split
+        if index == len(self.splits.list) - 1 and loop == split_image.loops:
+            return
+        
+        # Handle post-split delay
+        elif split_image.pause_duration > 0:
             self.suspended = True
             self.suspend_remaining = split_image.pause_duration
             start_time = time.perf_counter()
@@ -599,6 +607,3 @@ class Splitter:
                 time.sleep(self._interval)
             self.suspended = False
             self.suspend_remaining = None
-
-            if self._compare_thread_finished:
-                return

--- a/src/splitter/splitter.py
+++ b/src/splitter/splitter.py
@@ -591,7 +591,7 @@ class Splitter:
         # Don't delay after very last split
         if index == len(self.splits.list) - 1 and loop == split_image.loops:
             return
-        
+
         # Handle post-split delay
         elif split_image.pause_duration > 0:
             self.suspended = True

--- a/src/splitter/splitter.py
+++ b/src/splitter/splitter.py
@@ -103,7 +103,6 @@ class Splitter:
         self.comparison_frame = None
         self.frame_pixmap = None
         self.capture_thread = threading.Thread(target=self._capture)
-        self._ui_frame = None
         self._cap = None
         self._capture_thread_finished = False
 
@@ -298,9 +297,9 @@ class Splitter:
                 # Don't need to generate a separate ui_frame -- the
                 # comparison_frame is already the right size
                 if settings.get_bool("SHOW_MIN_VIEW"):
-                    self._ui_frame = None
+                    ui_frame = None
                 else:
-                    self._ui_frame = self.comparison_frame
+                    ui_frame = self.comparison_frame
 
             else:
                 self.comparison_frame = cv2.resize(
@@ -309,9 +308,9 @@ class Splitter:
                     interpolation=cv2.INTER_LINEAR,
                 )
                 if settings.get_bool("SHOW_MIN_VIEW"):
-                    self._ui_frame = None
+                    ui_frame = None
                 else:
-                    self._ui_frame = cv2.resize(
+                    ui_frame = cv2.resize(
                         frame,
                         (
                             settings.get_int("FRAME_WIDTH"),
@@ -320,12 +319,11 @@ class Splitter:
                         interpolation=cv2.INTER_NEAREST,
                     )
 
-            self.frame_pixmap = self._frame_to_pixmap(self._ui_frame)
+            self.frame_pixmap = self._frame_to_pixmap(ui_frame)
 
         self._cap.release()
 
         # Setting these to None tells ui_controller the capture isn't active
-        self._ui_frame = None
         self.comparison_frame = None
         self.frame_pixmap = None
 

--- a/src/ui/ui_controller.py
+++ b/src/ui/ui_controller.py
@@ -482,7 +482,9 @@ class UIController:
             self._settings_window.threshold_spinbox: str(
                 float(settings.get_float("DEFAULT_THRESHOLD") * 100)
             ),
-            self._settings_window.decimals_spinbox: settings.get_int("MATCH_PERCENT_DECIMALS"),
+            self._settings_window.decimals_spinbox: settings.get_int(
+                "MATCH_PERCENT_DECIMALS"
+            ),
             self._settings_window.delay_spinbox: settings.get_float("DEFAULT_DELAY"),
             self._settings_window.pause_spinbox: settings.get_float("DEFAULT_PAUSE"),
         }.items():
@@ -1325,7 +1327,7 @@ class UIController:
 
     def _update_split_delay_suspend(self) -> None:
         """Display remaining delay or suspend time.
-        
+
         Keep track of both overlays, regardless of view, so we can hide the one
         not currently in use.
         """

--- a/src/ui/ui_controller.py
+++ b/src/ui/ui_controller.py
@@ -1377,13 +1377,14 @@ class UIController:
             high_label.setText(format_str.format(high_percent * 100))
 
         # No splits loaded, but UI is showing threshold%
-        if current_index is None and thresh_label.text() != null_str:
-            thresh_label.setText(null_str)
+        if current_index is None:
+            if thresh_label.text() != null_str:
+                thresh_label.setText(null_str)
 
         # Update threshold%
-        elif current_index is not None:
-            thresh_percent = self._splitter.splits.list[current_index].threshold
-            thresh_label.setText(format_str.format(thresh_percent * 100))
+        else:
+            threshold = self._splitter.splits.list[current_index].threshold
+            thresh_label.setText(format_str.format(threshold * 100))
 
     def _update_pause_button(self):
         """Adjust the length and content of the pause button's text according

--- a/src/ui/ui_controller.py
+++ b/src/ui/ui_controller.py
@@ -68,10 +68,10 @@ class UIController:
 
         Creates each UI window and then shows the main window.
         Connects pyqtSignals from each UI window to their respective slots.
-        Sets initial flags and values used by _update_ui.
+        Sets initial flags and values used by _poller.
         Starts the keyboard listener.
-        Starts _update_ui_timer, which checks for user input and splitter
-        output at regular intervals.
+        Starts _poller, which checks for user input and splitter outputs at
+        regular intervals.
 
         Args:
             application (QApplication): The QApplication that the program is
@@ -89,44 +89,22 @@ class UIController:
         style_sheet.set_style(self._main_window, theme)
         style_sheet.set_style(self._settings_window, theme)
 
-        ############################
-        #                          #
-        # _update_ui Values, Flags #
-        #                          #
-        ############################
-
-        # Store most recent values based on splitter state
-        self._most_recent_split_index = None
-        self._most_recent_loop = None
-        self._most_recent_match_percent_decimals = settings.get_int(
-            "MATCH_PERCENT_DECIMALS"
-        )
-        self._most_recent_match_percent_format_string = (
-            f"{{:.{self._most_recent_match_percent_decimals}f}}"
-        )
-        self._most_recent_match_percent_null_string = self._null_match_percent_string()
+        #########################
+        #                       #
+        # _poller Values, Flags #
+        #                       #
+        #########################
 
         # Tell _update_ui to update split labels
+        # Should be set whenever the split image is modified
         self._redraw_split_labels = True
 
-        # Determine appropriate pause button text. This should ONLY be used
-        # from within the context of update_ui to check whether the splitter's
-        # suspended status has changed recently. Other methods should read the
-        # value directly from self._splitter.suspended, since that value is
-        # always 100% up-to-date.
-        self._splitter_suspended = None
-
-        # Enable buttons and hotkeys
-        self._video_active = None
-        self._splits_active = None
-        self._first_split_active = None
-        self._last_split_active = None
+        # Flags to disable hotkeys
         self._split_hotkey_enabled = False
         self._undo_hotkey_enabled = False
         self._skip_hotkey_enabled = False
 
-        # React to hotkey presses
-        self._settings_window_showing = False
+        # Flags for detecting hotkey presses
         self._split_hotkey_pressed = False
         self._reset_hotkey_pressed = False
         self._undo_hotkey_pressed = False
@@ -146,19 +124,17 @@ class UIController:
         self._set_main_window_layout()
 
         # "Update available" message box
-        self._main_window.update_available_message_box.buttonClicked.connect(
+        self._main_window.update_available_msg.buttonClicked.connect(
             self._update_message_box_action
         )
 
         # Split directory line edit
-        self._main_window.split_directory_line_edit.clicked.connect(
+        self._main_window.split_directory_box.clicked.connect(
             lambda: self._open_file_or_dir(settings.get_str("LAST_IMAGE_DIR"))
         )
 
         # Split directory button
-        self._main_window.split_directory_button.clicked.connect(
-            self._set_image_directory_path
-        )
+        self._main_window.split_dir_button.clicked.connect(self.set_split_dir_path)
 
         # Minimal view / full view button
         self._main_window.minimal_view_button.clicked.connect(
@@ -183,45 +159,35 @@ class UIController:
         self._main_window.screenshot_button.clicked.connect(self._take_screenshot)
 
         # Reload video button
-        self._main_window.reload_video_button.clicked.connect(
+        self._main_window.reconnect_button.clicked.connect(
             self._splitter.safe_exit_all_threads
         )
-        self._main_window.reload_video_button.clicked.connect(self._splitter.start)
+        self._main_window.reconnect_button.clicked.connect(self._splitter.start)
 
         # Pause comparison / unpause comparison button
-        self._main_window.pause_comparison_button.clicked.connect(
-            self._splitter.toggle_suspended
-        )
+        self._main_window.pause_button.clicked.connect(self._splitter.toggle_suspended)
 
         # Reset button
-        self._main_window.reset_splits_button.clicked.connect(
-            self._attempt_reset_hotkey
-        )
+        self._main_window.reset_button.clicked.connect(self._attempt_reset_hotkey)
 
         # Undo split button
-        self._main_window.undo_split_button.clicked.connect(self._attempt_undo_hotkey)
+        self._main_window.undo_button.clicked.connect(self._attempt_undo_hotkey)
 
         # Skip split button
-        self._main_window.skip_split_button.clicked.connect(self._attempt_skip_hotkey)
+        self._main_window.skip_button.clicked.connect(self._attempt_skip_hotkey)
 
         # Previous split button
-        self._main_window.previous_split_button.clicked.connect(
-            self._request_previous_split
-        )
+        self._main_window.previous_button.clicked.connect(self._request_previous_split)
 
         # Next split button
-        self._main_window.next_split_button.clicked.connect(self._request_next_split)
+        self._main_window.next_button.clicked.connect(self._request_next_split)
 
         # Settings window action
         self._main_window.settings_action.triggered.connect(self._exec_settings_window)
 
         # Help action
         self._main_window.help_action.triggered.connect(
-            lambda: webbrowser.open(
-                settings.USER_MANUAL_URL,
-                new=0,
-                autoraise=True,
-            )
+            lambda: webbrowser.open(settings.USER_MANUAL_URL, new=0, autoraise=True)
         )
 
         ##########################
@@ -230,27 +196,23 @@ class UIController:
         #                        #
         ##########################
 
+        close_settings = lambda: self._settings_window.done(0)
+
         # Close window convenience shortcut
-        self._settings_window.close_window_shortcut.activated.connect(
-            lambda: self._settings_window.done(0)
-        )
+        self._settings_window.close_window_shortcut.activated.connect(close_settings)
 
         # Cancel button
-        self._settings_window.cancel_button.clicked.connect(
-            lambda: self._settings_window.done(0)
-        )
+        self._settings_window.cancel_button.clicked.connect(close_settings)
 
         # Save button
         self._settings_window.save_button.clicked.connect(self._save_settings)
-        self._settings_window.save_button.clicked.connect(
-            lambda: self._settings_window.done(0)
-        )
+        self._settings_window.save_button.clicked.connect(close_settings)
 
-        #################
-        #               #
-        # Begin Polling #
-        #               #
-        #################
+        #######################################
+        #                                     #
+        # Start Polling Keyboard and Splitter #
+        #                                     #
+        #######################################
 
         # Start keyboard listener
         self._keyboard_controller = keyboard.Controller()
@@ -260,16 +222,20 @@ class UIController:
         self._keyboard_listener.start()
 
         # Start timer
-        self._update_ui_timer = QTimer()
-        self._update_ui_timer.setInterval(1000 // settings.get_int("FPS"))
-        self._update_ui_timer.timeout.connect(self._update_ui)
-        self._update_ui_timer.start()
+        self._poller = QTimer()
+        self._poller.setInterval(1000 // settings.get_int("FPS"))
+        self._poller.timeout.connect(self._poll)
+        self._poller.start()
 
         self._main_window.show()
 
+    def _poll(self) -> None:
+        self._update_from_splitter()
+        self._update_from_keyboard()
+
     ###########################
     #                         #
-    # React to UI Interaction #
+    # Manage User Interaction #
     #                         #
     ###########################
 
@@ -284,7 +250,7 @@ class UIController:
         a button in the UI, so the program MUST be in focus, so hotkeys
         will always work. Similarly, it is impossible for the settings window
         to be opened when this method is called, so we don't need to worry
-        about whether _settings_window_showing will block the hotkey flag
+        about whether the settings window will block the hotkey flag
         from being set.
 
         If this method is ever used to accomplish something
@@ -293,7 +259,6 @@ class UIController:
         """
         key_code = settings.get_str("UNDO_HOTKEY_CODE")
         if len(key_code) > 0:
-            # This leads to request_previous_split being called
             self._press_hotkey(key_code)
         else:
             self._request_previous_split()
@@ -309,7 +274,7 @@ class UIController:
         a button in the UI, so the program MUST be in focus, so hotkeys
         will always work. Similarly, it is impossible for the settings window
         to be opened when this method is called, so we don't need to worry
-        about whether _settings_window_showing will block the hotkey flag
+        about whether the settings window will block the hotkey flag
         from being set.
 
         If this method is ever used to accomplish something
@@ -318,7 +283,6 @@ class UIController:
         """
         key_code = settings.get_str("SKIP_HOTKEY_CODE")
         if len(key_code) > 0:
-            # This leads to request_next_split being called
             self._press_hotkey(key_code)
         else:
             self._request_next_split()
@@ -334,7 +298,7 @@ class UIController:
         a button in the UI, so the program MUST be in focus, so hotkeys
         will always work. Similarly, it is impossible for the settings window
         to be opened when this method is called, so we don't need to worry
-        about whether _settings_window_showing will block the hotkey flag
+        about whether the settings window will block the hotkey flag
         from being set.
 
         If this method is ever used to accomplish something
@@ -343,7 +307,6 @@ class UIController:
         """
         key_code = settings.get_str("RESET_HOTKEY_CODE")
         if len(key_code) > 0:
-            # This leads to request_previous_split being called
             self._press_hotkey(key_code)
         else:
             self._request_reset_splits()
@@ -352,7 +315,7 @@ class UIController:
         """Tell `splitter.splits` to call `previous_split_image`, and ask
         splitter._look_for_match to reset its flags if needed.
 
-        If self._splitter.current_match_percent is None, this means that
+        If self._splitter.match_percent is None, this means that
         splitter.look_for_match isn't active, and we can move to the next split
         image without causing a segmentation error or breaking splitter flags.
 
@@ -364,8 +327,10 @@ class UIController:
         the split image, then unset changing_splits, which signals to splitter
         it can reset its flags.
         """
+        self._redraw_split_labels = True  # Make sure UI image is updated
+
         # Go to next split, no need to worry about flags / thread safety
-        if self._splitter.current_match_percent is None:
+        if self._splitter.match_percent is None:
             self._splitter.splits.previous_split_image()
 
         # Pause splitter._look_for_match before getting next split
@@ -384,7 +349,7 @@ class UIController:
         """Tell `splitter.splits` to call `next_split_image`, and ask
         splitter._look_for_match to reset its flags if needed.
 
-        If self._splitter.current_match_percent is None, this means that
+        If self._splitter.match_percent is None, this means that
         splitter.look_for_match isn't active, and we can move to the next split
         image without causing a segmentation error or breaking splitter flags.
 
@@ -405,13 +370,24 @@ class UIController:
         the thread down on accident, so we also check if this method is being
         called as the result of a hotkey press.
         """
-        # Kill compare_thread if we're on the last split (see docstring for why)
-        if self._last_split_active and self._split_hotkey_pressed:
+        # Kill compare_thread instead if we're on the last split
+        # (This call must be the result of a split key hotpress)
+        # (See docstring)
+        split_index = self._splitter.splits.current_image_index
+        total_splits = len(self._splitter.splits.list) - 1
+        loop = self._splitter.splits.current_loop
+        total_loops = self._splitter.splits.list[split_index].loops
+        if (
+            split_index == total_splits
+            and loop == total_loops
+            and self._split_hotkey_pressed
+        ):
             self._splitter.safe_exit_compare_thread()
             return
 
+        self._redraw_split_labels = True  # Make sure UI image is updated
         # Go to next split, no need to worry about flags / thread safety
-        if self._splitter.current_match_percent is None:
+        if self._splitter.match_percent is None:
             self._splitter.splits.next_split_image()
 
         # Pause splitter._look_for_match before getting next split
@@ -444,7 +420,7 @@ class UIController:
         ):
             self._splitter.start_compare_thread()
 
-    def _set_image_directory_path(self) -> None:
+    def set_split_dir_path(self) -> None:
         """Prompt the user to select a split image directory, then open the new
         directory in a threadsafe manner.
 
@@ -459,50 +435,42 @@ class UIController:
         )
         if len(path) > 1 and path != settings.get_str("LAST_IMAGE_DIR"):
             settings.set_value("LAST_IMAGE_DIR", path)
-            self._set_split_directory_line_edit_text()
+            self._set_split_directory_box_text()
             self._request_reset_splits()
 
-    def _set_split_directory_line_edit_text(self) -> None:
+    def _set_split_directory_box_text(self) -> None:
         """Convert the split image directory path to an elided string,
         based on the current size of main window's split directory line edit.
         """
         path = settings.get_str("LAST_IMAGE_DIR")
-        elided_path = (
-            self._main_window.split_directory_line_edit.fontMetrics().elidedText(
-                f" {path} ",
-                Qt.ElideMiddle,
-                self._main_window.split_directory_line_edit.width(),
-            )
+        elided_path = self._main_window.split_directory_box.fontMetrics().elidedText(
+            f" {path} ",
+            Qt.ElideMiddle,
+            self._main_window.split_directory_box.width(),
         )
-        self._main_window.split_directory_line_edit.setText(elided_path)
+        self._main_window.split_directory_box.setText(elided_path)
 
     def _update_message_box_action(self, button: QAbstractButton):
-        """React to button press in _main_window.update_available_message_box.
+        """React to button press in _main_window.update_available_msg.
 
         Args:
             button (QAbstractButton): The button that was pressed.
         """
         # "Don't ask again" was clicked -- stop checking for updates
-        if button.text() == self._main_window.update_available_never_button_text:
+        if button.text() == self._main_window.never_button_txt:
             settings.set_value("CHECK_FOR_UPDATES", False)
 
         # "Open" was clicked -- open the GitHub releases page
-        elif button.text() == self._main_window.update_available_open_button_text:
+        elif button.text() == self._main_window.open_button_txt:
             webbrowser.open(
                 f"{settings.REPO_URL}releases/latest", new=0, autoraise=True
             )
 
     def _exec_settings_window(self) -> None:
-        """Set up and open the settings window UI.
-
-        Because exec() blocks, _settings_window_showing isn't set to false
-        until the user closes the settings window.
-        """
+        """Set up and open the settings window UI."""
         self._settings_window.setFocus(True)  # Make sure no widgets have focus
         self._reset_settings()
-        self._settings_window_showing = True
         self._settings_window.exec()
-        self._settings_window_showing = False
 
     def _reset_settings(self) -> None:
         """Read settings from `settings.py` and write them into the settings
@@ -511,18 +479,12 @@ class UIController:
         # Spinboxes
         for spinbox, value in {
             self._settings_window.fps_spinbox: settings.get_int("FPS"),
-            self._settings_window.default_threshold_double_spinbox: str(
+            self._settings_window.threshold_spinbox: str(
                 float(settings.get_float("DEFAULT_THRESHOLD") * 100)
             ),
-            self._settings_window.match_percent_decimals_spinbox: settings.get_int(
-                "MATCH_PERCENT_DECIMALS"
-            ),
-            self._settings_window.default_delay_double_spinbox: settings.get_float(
-                "DEFAULT_DELAY"
-            ),
-            self._settings_window.default_pause_double_spinbox: settings.get_float(
-                "DEFAULT_PAUSE"
-            ),
+            self._settings_window.decimals_spinbox: settings.get_int("MATCH_PERCENT_DECIMALS"),
+            self._settings_window.delay_spinbox: settings.get_float("DEFAULT_DELAY"),
+            self._settings_window.pause_spinbox: settings.get_float("DEFAULT_PAUSE"),
         }.items():
             spinbox.setProperty("value", value)
 
@@ -547,47 +509,47 @@ class UIController:
                 checkbox.setCheckState(Qt.Unchecked)
 
         # Hotkeys
-        for hotkey_line_edit, values in {
-            self._settings_window.split_hotkey_line_edit: (
+        for hotkey_box, values in {
+            self._settings_window.split_hotkey_box: (
                 settings.get_str("SPLIT_HOTKEY_NAME"),
                 settings.get_str("SPLIT_HOTKEY_CODE"),
             ),
-            self._settings_window.reset_hotkey_line_edit: (
+            self._settings_window.reset_hotkey_box: (
                 settings.get_str("RESET_HOTKEY_NAME"),
                 settings.get_str("RESET_HOTKEY_CODE"),
             ),
-            self._settings_window.pause_hotkey_line_edit: (
+            self._settings_window.pause_hotkey_box: (
                 settings.get_str("PAUSE_HOTKEY_NAME"),
                 settings.get_str("PAUSE_HOTKEY_CODE"),
             ),
-            self._settings_window.undo_split_hotkey_line_edit: (
+            self._settings_window.undo_hotkey_box: (
                 settings.get_str("UNDO_HOTKEY_NAME"),
                 settings.get_str("UNDO_HOTKEY_CODE"),
             ),
-            self._settings_window.skip_split_hotkey_line_edit: (
+            self._settings_window.skip_hotkey_box: (
                 settings.get_str("SKIP_HOTKEY_NAME"),
                 settings.get_str("SKIP_HOTKEY_CODE"),
             ),
-            self._settings_window.previous_split_hotkey_line_edit: (
+            self._settings_window.previous_hotkey_box: (
                 settings.get_str("PREVIOUS_HOTKEY_NAME"),
                 settings.get_str("PREVIOUS_HOTKEY_CODE"),
             ),
-            self._settings_window.next_split_hotkey_line_edit: (
+            self._settings_window.next_hotkey_box: (
                 settings.get_str("NEXT_HOTKEY_NAME"),
                 settings.get_str("NEXT_HOTKEY_CODE"),
             ),
-            self._settings_window.screenshot_hotkey_line_edit: (
+            self._settings_window.screenshot_hotkey_box: (
                 settings.get_str("SCREENSHOT_HOTKEY_NAME"),
                 settings.get_str("SCREENSHOT_HOTKEY_CODE"),
             ),
-            self._settings_window.toggle_global_hotkeys_hotkey_line_edit: (
+            self._settings_window.toggle_global_hotkeys_hotkey_box: (
                 settings.get_str("TOGGLE_HOTKEYS_HOTKEY_NAME"),
                 settings.get_str("TOGGLE_HOTKEYS_HOTKEY_CODE"),
             ),
         }.items():
-            hotkey_line_edit.setText(values[0])
-            hotkey_line_edit.key_name = values[0]
-            hotkey_line_edit.key_code = values[1]
+            hotkey_box.setText(values[0])
+            hotkey_box.key_name = values[0]
+            hotkey_box.key_code = values[1]
 
         # Comboboxes
         aspect_ratio = settings.get_str("ASPECT_RATIO")
@@ -613,19 +575,19 @@ class UIController:
         # Spinboxes
         for spinbox, setting_string in {
             self._settings_window.fps_spinbox: "FPS",
-            self._settings_window.default_threshold_double_spinbox: "DEFAULT_THRESHOLD",
-            self._settings_window.match_percent_decimals_spinbox: "MATCH_PERCENT_DECIMALS",
-            self._settings_window.default_delay_double_spinbox: "DEFAULT_DELAY",
-            self._settings_window.default_pause_double_spinbox: "DEFAULT_PAUSE",
+            self._settings_window.threshold_spinbox: "DEFAULT_THRESHOLD",
+            self._settings_window.decimals_spinbox: "MATCH_PERCENT_DECIMALS",
+            self._settings_window.delay_spinbox: "DEFAULT_DELAY",
+            self._settings_window.pause_spinbox: "DEFAULT_PAUSE",
         }.items():
-            if spinbox == self._settings_window.default_threshold_double_spinbox:
+            if spinbox == self._settings_window.threshold_spinbox:
                 value = float(spinbox.value()) / 100
             else:
                 value = spinbox.value()
 
             # Send new FPS value to controller and splitter
             if spinbox == self._settings_window.fps_spinbox:
-                self._update_ui_timer.setInterval(1000 // value)
+                self._poller.setInterval(1000 // value)
                 self._splitter.target_fps = value
 
             settings.set_value(setting_string, value)
@@ -649,39 +611,39 @@ class UIController:
 
         # Hotkeys
         for hotkey, setting_strings in {
-            self._settings_window.split_hotkey_line_edit: (
+            self._settings_window.split_hotkey_box: (
                 "SPLIT_HOTKEY_NAME",
                 "SPLIT_HOTKEY_CODE",
             ),
-            self._settings_window.reset_hotkey_line_edit: (
+            self._settings_window.reset_hotkey_box: (
                 "RESET_HOTKEY_NAME",
                 "RESET_HOTKEY_CODE",
             ),
-            self._settings_window.pause_hotkey_line_edit: (
+            self._settings_window.pause_hotkey_box: (
                 "PAUSE_HOTKEY_NAME",
                 "PAUSE_HOTKEY_CODE",
             ),
-            self._settings_window.undo_split_hotkey_line_edit: (
+            self._settings_window.undo_hotkey_box: (
                 "UNDO_HOTKEY_NAME",
                 "UNDO_HOTKEY_CODE",
             ),
-            self._settings_window.skip_split_hotkey_line_edit: (
+            self._settings_window.skip_hotkey_box: (
                 "SKIP_HOTKEY_NAME",
                 "SKIP_HOTKEY_CODE",
             ),
-            self._settings_window.previous_split_hotkey_line_edit: (
+            self._settings_window.previous_hotkey_box: (
                 "PREVIOUS_HOTKEY_NAME",
                 "PREVIOUS_HOTKEY_CODE",
             ),
-            self._settings_window.next_split_hotkey_line_edit: (
+            self._settings_window.next_hotkey_box: (
                 "NEXT_HOTKEY_NAME",
                 "NEXT_HOTKEY_CODE",
             ),
-            self._settings_window.screenshot_hotkey_line_edit: (
+            self._settings_window.screenshot_hotkey_box: (
                 "SCREENSHOT_HOTKEY_NAME",
                 "SCREENSHOT_HOTKEY_CODE",
             ),
-            self._settings_window.toggle_global_hotkeys_hotkey_line_edit: (
+            self._settings_window.toggle_global_hotkeys_hotkey_box: (
                 "TOGGLE_HOTKEYS_HOTKEY_NAME",
                 "TOGGLE_HOTKEYS_HOTKEY_CODE",
             ),
@@ -729,7 +691,7 @@ class UIController:
         """
         frame = self._splitter.comparison_frame
         if frame is None:
-            message = self._main_window.screenshot_error_no_video_message_box
+            message = self._main_window.screenshot_err_no_video
             message.show()
             # Close message box after 10 seconds
             QTimer.singleShot(10000, lambda: message.done(0))
@@ -740,7 +702,7 @@ class UIController:
             image_dir = os.path.expanduser("~")  # Home directory is default
 
         screenshot_path = (
-            f"{image_dir}/{self._get_unique_filename_number(image_dir)}_screenshot.png"
+            f"{image_dir}/{self.get_file_number(image_dir)}_screenshot.png"
         )
         cv2.imwrite(screenshot_path, frame)
 
@@ -748,14 +710,14 @@ class UIController:
             if settings.get_bool("OPEN_SCREENSHOT_ON_CAPTURE"):
                 self._open_file_or_dir(screenshot_path)
             else:
-                self._main_window.screenshot_success_message_box.setInformativeText(
+                self._main_window.screenshot_ok_msg.setInformativeText(
                     f"Screenshot saved to:\n{screenshot_path}"
                 )
-                self._main_window.screenshot_success_message_box.setIconPixmap(
+                self._main_window.screenshot_ok_msg.setIconPixmap(
                     QPixmap(screenshot_path).scaledToWidth(150)
                 )
 
-                message = self._main_window.screenshot_success_message_box
+                message = self._main_window.screenshot_ok_msg
                 message.show()
                 # Close message box after 10 seconds
                 QTimer.singleShot(10000, lambda: message.done(0))
@@ -766,7 +728,7 @@ class UIController:
             # Close message box after 10 seconds
             QTimer.singleShot(10000, lambda: message.done(0))
 
-    def _get_unique_filename_number(self, dir: str) -> str:
+    def get_file_number(self, dir: str) -> str:
         """Return the lowest three-digit number that will allow a unique
         filename in this format: "xxx_screenshot.png"
 
@@ -805,7 +767,7 @@ class UIController:
             path (str): The file to open.
         """
         if not Path(path).exists():
-            message = self._main_window.file_not_found_message_box
+            message = self._main_window.err_not_found_msg
             message.show()
             # Close message box after 10 seconds
             QTimer.singleShot(10000, lambda: message.done(0))
@@ -838,161 +800,56 @@ class UIController:
         # Split labels will be refreshed after this call finishes
         self._redraw_split_labels = True
         # Refresh the split directory text so it elides correctly
-        self._set_split_directory_line_edit_text()
+        self._set_split_directory_box_text()
 
     def _set_minimal_view(self) -> None:
         """Resize and show widgets so that minimal view is displayed."""
-        self._main_window.previous_split_button.setGeometry(
-            QRect(
-                60 + self._main_window.LEFT_EDGE_CORRECTION,
-                224 + self._main_window.TOP_EDGE_CORRECTION,
-                31,
-                31,
-            )
+        left = self._main_window.LEFT_EDGE_CORRECTION
+        top = self._main_window.TOP_EDGE_CORRECTION
+        self._main_window.previous_button.setGeometry(
+            QRect(60 + left, 224 + top, 31, 31)
         )
         self._main_window.split_name_label.setGeometry(
-            QRect(
-                92 + self._main_window.LEFT_EDGE_CORRECTION,
-                214 + self._main_window.TOP_EDGE_CORRECTION,
-                251,
-                31,
-            )
+            QRect(92 + left, 214 + top, 251, 31)
         )
-        self._main_window.split_image_loop_label.setGeometry(
-            QRect(
-                92 + self._main_window.LEFT_EDGE_CORRECTION,
-                239 + self._main_window.TOP_EDGE_CORRECTION,
-                251,
-                31,
-            )
+        self._main_window.split_loop_label.setGeometry(
+            QRect(92 + left, 239 + top, 251, 31)
         )
-        self._main_window.next_split_button.setGeometry(
-            QRect(
-                344 + self._main_window.LEFT_EDGE_CORRECTION,
-                224 + self._main_window.TOP_EDGE_CORRECTION,
-                31,
-                31,
-            )
-        )
+        self._main_window.next_button.setGeometry(QRect(344 + left, 224 + top, 31, 31))
         self._main_window.minimal_view_button.setGeometry(
-            QRect(
-                60 + self._main_window.LEFT_EDGE_CORRECTION,
-                270 + self._main_window.TOP_EDGE_CORRECTION,
-                100,
-                31,
-            )
+            QRect(60 + left, 270 + top, 100, 31)
         )
-        self._main_window.video_feed_label.setGeometry(
-            QRect(
-                161 + self._main_window.LEFT_EDGE_CORRECTION,
-                270 + self._main_window.TOP_EDGE_CORRECTION,
-                213,
-                31,
-            )
+        self._main_window.video_title.setGeometry(QRect(161 + left, 270 + top, 213, 31))
+        self._main_window.pause_button.setGeometry(QRect(60 + left, 310 + top, 121, 31))
+        self._main_window.skip_button.setGeometry(QRect(125 + left, 350 + top, 56, 31))
+        self._main_window.undo_button.setGeometry(QRect(60 + left, 350 + top, 56, 31))
+        self._main_window.reset_button.setGeometry(QRect(304 + left, 310 + top, 71, 71))
+        self._main_window.match_percent_label.setGeometry(
+            QRect(62 + left, 304 + top, 161, 31)
         )
-        self._main_window.pause_comparison_button.setGeometry(
-            QRect(
-                60 + self._main_window.LEFT_EDGE_CORRECTION,
-                310 + self._main_window.TOP_EDGE_CORRECTION,
-                121,
-                31,
-            )
+        self._main_window.highest_percent_label.setGeometry(
+            QRect(62 + left, 331 + top, 161, 31)
         )
-        self._main_window.skip_split_button.setGeometry(
-            QRect(
-                125 + self._main_window.LEFT_EDGE_CORRECTION,
-                350 + self._main_window.TOP_EDGE_CORRECTION,
-                56,
-                31,
-            )
+        self._main_window.threshold_percent_label.setGeometry(
+            QRect(62 + left, 358 + top, 161, 31)
         )
-        self._main_window.undo_split_button.setGeometry(
-            QRect(
-                60 + self._main_window.LEFT_EDGE_CORRECTION,
-                350 + self._main_window.TOP_EDGE_CORRECTION,
-                56,
-                31,
-            )
+        self._main_window.match_percent.setGeometry(
+            QRect(227 + left, 304 + top, 46, 31)
         )
-        self._main_window.reset_splits_button.setGeometry(
-            QRect(
-                304 + self._main_window.LEFT_EDGE_CORRECTION,
-                310 + self._main_window.TOP_EDGE_CORRECTION,
-                71,
-                71,
-            )
+        self._main_window.highest_percent.setGeometry(
+            QRect(227 + left, 331 + top, 46, 31)
         )
-        self._main_window.current_match_percent_label.setGeometry(
-            QRect(
-                62 + self._main_window.LEFT_EDGE_CORRECTION,
-                304 + self._main_window.TOP_EDGE_CORRECTION,
-                161,
-                31,
-            )
+        self._main_window.threshold_percent.setGeometry(
+            QRect(227 + left, 358 + top, 46, 31)
         )
-        self._main_window.highest_match_percent_label.setGeometry(
-            QRect(
-                62 + self._main_window.LEFT_EDGE_CORRECTION,
-                331 + self._main_window.TOP_EDGE_CORRECTION,
-                161,
-                31,
-            )
+        self._main_window.percent_sign_1.setGeometry(
+            QRect(282 + left, 304 + top, 21, 31)
         )
-        self._main_window.threshold_match_percent_label.setGeometry(
-            QRect(
-                62 + self._main_window.LEFT_EDGE_CORRECTION,
-                358 + self._main_window.TOP_EDGE_CORRECTION,
-                161,
-                31,
-            )
+        self._main_window.percent_sign_2.setGeometry(
+            QRect(282 + left, 331 + top, 21, 31)
         )
-        self._main_window.current_match_percent.setGeometry(
-            QRect(
-                227 + self._main_window.LEFT_EDGE_CORRECTION,
-                304 + self._main_window.TOP_EDGE_CORRECTION,
-                46,
-                31,
-            )
-        )
-        self._main_window.highest_match_percent.setGeometry(
-            QRect(
-                227 + self._main_window.LEFT_EDGE_CORRECTION,
-                331 + self._main_window.TOP_EDGE_CORRECTION,
-                46,
-                31,
-            )
-        )
-        self._main_window.threshold_match_percent.setGeometry(
-            QRect(
-                227 + self._main_window.LEFT_EDGE_CORRECTION,
-                358 + self._main_window.TOP_EDGE_CORRECTION,
-                46,
-                31,
-            )
-        )
-        self._main_window.current_match_percent_sign.setGeometry(
-            QRect(
-                282 + self._main_window.LEFT_EDGE_CORRECTION,
-                304 + self._main_window.TOP_EDGE_CORRECTION,
-                21,
-                31,
-            )
-        )
-        self._main_window.highest_match_percent_sign.setGeometry(
-            QRect(
-                282 + self._main_window.LEFT_EDGE_CORRECTION,
-                331 + self._main_window.TOP_EDGE_CORRECTION,
-                21,
-                31,
-            )
-        )
-        self._main_window.threshold_match_percent_sign.setGeometry(
-            QRect(
-                282 + self._main_window.LEFT_EDGE_CORRECTION,
-                358 + self._main_window.TOP_EDGE_CORRECTION,
-                21,
-                31,
-            )
+        self._main_window.percent_sign_3.setGeometry(
+            QRect(282 + left, 358 + top, 21, 31)
         )
 
         self._set_nonessential_widgets_visible(False)
@@ -1001,215 +858,79 @@ class UIController:
 
     def _set_480x360_view(self) -> None:
         """Resize and show widgets so the 480x360 display is shown."""
-        self._main_window.split_directory_line_edit.setGeometry(
-            QRect(
-                247 + self._main_window.LEFT_EDGE_CORRECTION,
-                225 + self._main_window.TOP_EDGE_CORRECTION,
-                785,
-                30,
-            )
+        left = self._main_window.LEFT_EDGE_CORRECTION
+        top = self._main_window.TOP_EDGE_CORRECTION
+        self._main_window.split_directory_box.setGeometry(
+            QRect(247 + left, 225 + top, 785, 30)
         )
-        self._main_window.video_feed_label.setGeometry(
-            QRect(
-                260 + self._main_window.LEFT_EDGE_CORRECTION,
-                272 + self._main_window.TOP_EDGE_CORRECTION,
-                80,
-                31,
-            )
-        )
+        self._main_window.video_title.setGeometry(QRect(260 + left, 272 + top, 80, 31))
         self._main_window.split_name_label.setGeometry(
-            QRect(
-                584 + self._main_window.LEFT_EDGE_CORRECTION,
-                255 + self._main_window.TOP_EDGE_CORRECTION,
-                415,
-                31,
-            )
+            QRect(584 + left, 255 + top, 415, 31)
         )
-        self._main_window.split_image_loop_label.setGeometry(
-            QRect(
-                584 + self._main_window.LEFT_EDGE_CORRECTION,
-                280 + self._main_window.TOP_EDGE_CORRECTION,
-                415,
-                31,
-            )
+        self._main_window.split_loop_label.setGeometry(
+            QRect(584 + left, 280 + top, 415, 31)
         )
-        self._main_window.current_match_percent_label.setGeometry(
-            QRect(
-                80 + self._main_window.LEFT_EDGE_CORRECTION,
-                680 + self._main_window.TOP_EDGE_CORRECTION,
-                161,
-                31,
-            )
+        self._main_window.match_percent_label.setGeometry(
+            QRect(80 + left, 680 + top, 161, 31)
         )
-        self._main_window.highest_match_percent_label.setGeometry(
-            QRect(
-                80 + self._main_window.LEFT_EDGE_CORRECTION,
-                710 + self._main_window.TOP_EDGE_CORRECTION,
-                161,
-                31,
-            )
+        self._main_window.highest_percent_label.setGeometry(
+            QRect(80 + left, 710 + top, 161, 31)
         )
-        self._main_window.threshold_match_percent_label.setGeometry(
-            QRect(
-                80 + self._main_window.LEFT_EDGE_CORRECTION,
-                740 + self._main_window.TOP_EDGE_CORRECTION,
-                161,
-                31,
-            )
+        self._main_window.threshold_percent_label.setGeometry(
+            QRect(80 + left, 740 + top, 161, 31)
         )
-        self._main_window.current_match_percent.setGeometry(
-            QRect(
-                245 + self._main_window.LEFT_EDGE_CORRECTION,
-                680 + self._main_window.TOP_EDGE_CORRECTION,
-                46,
-                31,
-            )
+        self._main_window.match_percent.setGeometry(
+            QRect(245 + left, 680 + top, 46, 31)
         )
-        self._main_window.highest_match_percent.setGeometry(
-            QRect(
-                245 + self._main_window.LEFT_EDGE_CORRECTION,
-                710 + self._main_window.TOP_EDGE_CORRECTION,
-                46,
-                31,
-            )
+        self._main_window.highest_percent.setGeometry(
+            QRect(245 + left, 710 + top, 46, 31)
         )
-        self._main_window.threshold_match_percent.setGeometry(
-            QRect(
-                245 + self._main_window.LEFT_EDGE_CORRECTION,
-                740 + self._main_window.TOP_EDGE_CORRECTION,
-                46,
-                31,
-            )
+        self._main_window.threshold_percent.setGeometry(
+            QRect(245 + left, 740 + top, 46, 31)
         )
-        self._main_window.current_match_percent_sign.setGeometry(
-            QRect(
-                300 + self._main_window.LEFT_EDGE_CORRECTION,
-                680 + self._main_window.TOP_EDGE_CORRECTION,
-                21,
-                31,
-            )
+        self._main_window.percent_sign_1.setGeometry(
+            QRect(300 + left, 680 + top, 21, 31)
         )
-        self._main_window.highest_match_percent_sign.setGeometry(
-            QRect(
-                300 + self._main_window.LEFT_EDGE_CORRECTION,
-                710 + self._main_window.TOP_EDGE_CORRECTION,
-                21,
-                31,
-            )
+        self._main_window.percent_sign_2.setGeometry(
+            QRect(300 + left, 710 + top, 21, 31)
         )
-        self._main_window.threshold_match_percent_sign.setGeometry(
-            QRect(
-                300 + self._main_window.LEFT_EDGE_CORRECTION,
-                740 + self._main_window.TOP_EDGE_CORRECTION,
-                21,
-                31,
-            )
+        self._main_window.percent_sign_3.setGeometry(
+            QRect(300 + left, 740 + top, 21, 31)
         )
-        self._main_window.split_directory_button.setGeometry(
-            QRect(
-                60 + self._main_window.LEFT_EDGE_CORRECTION,
-                225 + self._main_window.TOP_EDGE_CORRECTION,
-                180,
-                30,
-            )
+        self._main_window.split_dir_button.setGeometry(
+            QRect(60 + left, 225 + top, 180, 30)
         )
         self._main_window.minimal_view_button.setGeometry(
-            QRect(
-                60 + self._main_window.LEFT_EDGE_CORRECTION,
-                270 + self._main_window.TOP_EDGE_CORRECTION,
-                100,
-                31,
-            )
+            QRect(60 + left, 270 + top, 100, 31)
         )
         self._main_window.next_source_button.setGeometry(
-            QRect(
-                440 + self._main_window.LEFT_EDGE_CORRECTION,
-                270 + self._main_window.TOP_EDGE_CORRECTION,
-                100,
-                31,
-            )
+            QRect(440 + left, 270 + top, 100, 31)
         )
         self._main_window.screenshot_button.setGeometry(
-            QRect(
-                340 + self._main_window.LEFT_EDGE_CORRECTION,
-                680 + self._main_window.TOP_EDGE_CORRECTION,
-                171,
-                41,
-            )
+            QRect(340 + left, 680 + top, 171, 41)
         )
-        self._main_window.reload_video_button.setGeometry(
-            QRect(
-                340 + self._main_window.LEFT_EDGE_CORRECTION,
-                730 + self._main_window.TOP_EDGE_CORRECTION,
-                171,
-                41,
-            )
+        self._main_window.reconnect_button.setGeometry(
+            QRect(340 + left, 730 + top, 171, 41)
         )
-        self._main_window.previous_split_button.setGeometry(
-            QRect(
-                550 + self._main_window.LEFT_EDGE_CORRECTION,
-                270 + self._main_window.TOP_EDGE_CORRECTION,
-                31,
-                31,
-            )
+        self._main_window.previous_button.setGeometry(
+            QRect(550 + left, 270 + top, 31, 31)
         )
-        self._main_window.next_split_button.setGeometry(
-            QRect(
-                1000 + self._main_window.LEFT_EDGE_CORRECTION,
-                270 + self._main_window.TOP_EDGE_CORRECTION,
-                31,
-                31,
-            )
+        self._main_window.next_button.setGeometry(QRect(1000 + left, 270 + top, 31, 31))
+        self._main_window.pause_button.setGeometry(
+            QRect(580 + left, 680 + top, 191, 41)
         )
-        self._main_window.pause_comparison_button.setGeometry(
-            QRect(
-                580 + self._main_window.LEFT_EDGE_CORRECTION,
-                680 + self._main_window.TOP_EDGE_CORRECTION,
-                191,
-                41,
-            )
+        self._main_window.skip_button.setGeometry(QRect(680 + left, 730 + top, 91, 41))
+        self._main_window.undo_button.setGeometry(QRect(580 + left, 730 + top, 91, 41))
+        self._main_window.reset_button.setGeometry(
+            QRect(810 + left, 680 + top, 191, 91)
         )
-        self._main_window.skip_split_button.setGeometry(
-            QRect(
-                680 + self._main_window.LEFT_EDGE_CORRECTION,
-                730 + self._main_window.TOP_EDGE_CORRECTION,
-                91,
-                41,
-            )
-        )
-        self._main_window.undo_split_button.setGeometry(
-            QRect(
-                580 + self._main_window.LEFT_EDGE_CORRECTION,
-                730 + self._main_window.TOP_EDGE_CORRECTION,
-                91,
-                41,
-            )
-        )
-        self._main_window.reset_splits_button.setGeometry(
-            QRect(
-                810 + self._main_window.LEFT_EDGE_CORRECTION,
-                680 + self._main_window.TOP_EDGE_CORRECTION,
-                191,
-                91,
-            )
-        )
-        self._main_window.video_feed_display.setGeometry(
-            QRect(
-                60 + self._main_window.LEFT_EDGE_CORRECTION,
-                310 + self._main_window.TOP_EDGE_CORRECTION,
-                480,
-                360,
-            )
+        self._main_window.video_display.setGeometry(
+            QRect(60 + left, 310 + top, 480, 360)
         )
 
-        split_image_geometry = QRect(
-            550 + self._main_window.LEFT_EDGE_CORRECTION,
-            310 + self._main_window.TOP_EDGE_CORRECTION,
-            480,
-            360,
-        )
-        self._main_window.split_image_display.setGeometry(split_image_geometry)
-        self._main_window.split_image_overlay.setGeometry(split_image_geometry)
+        split_image_geometry = QRect(550 + left, 310 + top, 480, 360)
+        self._main_window.split_display.setGeometry(split_image_geometry)
+        self._main_window.split_overlay.setGeometry(split_image_geometry)
 
         self._set_nonessential_widgets_visible(True)
         self._set_button_and_label_text(truncate=False)
@@ -1217,215 +938,79 @@ class UIController:
 
     def _set_320x240_view(self) -> None:
         """Resize and show widgets so the 320x240 display is shown."""
-        self._main_window.split_directory_line_edit.setGeometry(
-            QRect(
-                247 + self._main_window.LEFT_EDGE_CORRECTION,
-                225 + self._main_window.TOP_EDGE_CORRECTION,
-                464,
-                30,
-            )
+        left = self._main_window.LEFT_EDGE_CORRECTION
+        top = self._main_window.TOP_EDGE_CORRECTION
+        self._main_window.split_directory_box.setGeometry(
+            QRect(247 + left, 225 + top, 464, 30)
         )
-        self._main_window.video_feed_label.setGeometry(
-            QRect(
-                180 + self._main_window.LEFT_EDGE_CORRECTION,
-                272 + self._main_window.TOP_EDGE_CORRECTION,
-                80,
-                31,
-            )
-        )
+        self._main_window.video_title.setGeometry(QRect(180 + left, 272 + top, 80, 31))
         self._main_window.split_name_label.setGeometry(
-            QRect(
-                424 + self._main_window.LEFT_EDGE_CORRECTION,
-                255 + self._main_window.TOP_EDGE_CORRECTION,
-                254,
-                31,
-            )
+            QRect(424 + left, 255 + top, 254, 31)
         )
-        self._main_window.split_image_loop_label.setGeometry(
-            QRect(
-                424 + self._main_window.LEFT_EDGE_CORRECTION,
-                280 + self._main_window.TOP_EDGE_CORRECTION,
-                254,
-                31,
-            )
+        self._main_window.split_loop_label.setGeometry(
+            QRect(424 + left, 280 + top, 254, 31)
         )
-        self._main_window.current_match_percent_label.setGeometry(
-            QRect(
-                -50 + self._main_window.LEFT_EDGE_CORRECTION,
-                560 + self._main_window.TOP_EDGE_CORRECTION,
-                161,
-                31,
-            )
+        self._main_window.match_percent_label.setGeometry(
+            QRect(-50 + left, 560 + top, 161, 31)
         )
-        self._main_window.highest_match_percent_label.setGeometry(
-            QRect(
-                -50 + self._main_window.LEFT_EDGE_CORRECTION,
-                590 + self._main_window.TOP_EDGE_CORRECTION,
-                161,
-                31,
-            )
+        self._main_window.highest_percent_label.setGeometry(
+            QRect(-50 + left, 590 + top, 161, 31)
         )
-        self._main_window.threshold_match_percent_label.setGeometry(
-            QRect(
-                -50 + self._main_window.LEFT_EDGE_CORRECTION,
-                620 + self._main_window.TOP_EDGE_CORRECTION,
-                161,
-                31,
-            )
+        self._main_window.threshold_percent_label.setGeometry(
+            QRect(-50 + left, 620 + top, 161, 31)
         )
-        self._main_window.current_match_percent.setGeometry(
-            QRect(
-                115 + self._main_window.LEFT_EDGE_CORRECTION,
-                560 + self._main_window.TOP_EDGE_CORRECTION,
-                46,
-                31,
-            )
+        self._main_window.match_percent.setGeometry(
+            QRect(115 + left, 560 + top, 46, 31)
         )
-        self._main_window.highest_match_percent.setGeometry(
-            QRect(
-                115 + self._main_window.LEFT_EDGE_CORRECTION,
-                590 + self._main_window.TOP_EDGE_CORRECTION,
-                46,
-                31,
-            )
+        self._main_window.highest_percent.setGeometry(
+            QRect(115 + left, 590 + top, 46, 31)
         )
-        self._main_window.threshold_match_percent.setGeometry(
-            QRect(
-                115 + self._main_window.LEFT_EDGE_CORRECTION,
-                620 + self._main_window.TOP_EDGE_CORRECTION,
-                46,
-                31,
-            )
+        self._main_window.threshold_percent.setGeometry(
+            QRect(115 + left, 620 + top, 46, 31)
         )
-        self._main_window.current_match_percent_sign.setGeometry(
-            QRect(
-                170 + self._main_window.LEFT_EDGE_CORRECTION,
-                560 + self._main_window.TOP_EDGE_CORRECTION,
-                21,
-                31,
-            )
+        self._main_window.percent_sign_1.setGeometry(
+            QRect(170 + left, 560 + top, 21, 31)
         )
-        self._main_window.highest_match_percent_sign.setGeometry(
-            QRect(
-                170 + self._main_window.LEFT_EDGE_CORRECTION,
-                590 + self._main_window.TOP_EDGE_CORRECTION,
-                21,
-                31,
-            )
+        self._main_window.percent_sign_2.setGeometry(
+            QRect(170 + left, 590 + top, 21, 31)
         )
-        self._main_window.threshold_match_percent_sign.setGeometry(
-            QRect(
-                170 + self._main_window.LEFT_EDGE_CORRECTION,
-                620 + self._main_window.TOP_EDGE_CORRECTION,
-                21,
-                31,
-            )
+        self._main_window.percent_sign_3.setGeometry(
+            QRect(170 + left, 620 + top, 21, 31)
         )
-        self._main_window.split_directory_button.setGeometry(
-            QRect(
-                60 + self._main_window.LEFT_EDGE_CORRECTION,
-                225 + self._main_window.TOP_EDGE_CORRECTION,
-                180,
-                30,
-            )
+        self._main_window.split_dir_button.setGeometry(
+            QRect(60 + left, 225 + top, 180, 30)
         )
         self._main_window.minimal_view_button.setGeometry(
-            QRect(
-                60 + self._main_window.LEFT_EDGE_CORRECTION,
-                270 + self._main_window.TOP_EDGE_CORRECTION,
-                100,
-                31,
-            )
+            QRect(60 + left, 270 + top, 100, 31)
         )
         self._main_window.next_source_button.setGeometry(
-            QRect(
-                280 + self._main_window.LEFT_EDGE_CORRECTION,
-                270 + self._main_window.TOP_EDGE_CORRECTION,
-                100,
-                31,
-            )
+            QRect(280 + left, 270 + top, 100, 31)
         )
         self._main_window.screenshot_button.setGeometry(
-            QRect(
-                220 + self._main_window.LEFT_EDGE_CORRECTION,
-                560 + self._main_window.TOP_EDGE_CORRECTION,
-                131,
-                41,
-            )
+            QRect(220 + left, 560 + top, 131, 41)
         )
-        self._main_window.reload_video_button.setGeometry(
-            QRect(
-                220 + self._main_window.LEFT_EDGE_CORRECTION,
-                610 + self._main_window.TOP_EDGE_CORRECTION,
-                131,
-                41,
-            )
+        self._main_window.reconnect_button.setGeometry(
+            QRect(220 + left, 610 + top, 131, 41)
         )
-        self._main_window.previous_split_button.setGeometry(
-            QRect(
-                390 + self._main_window.LEFT_EDGE_CORRECTION,
-                270 + self._main_window.TOP_EDGE_CORRECTION,
-                31,
-                31,
-            )
+        self._main_window.previous_button.setGeometry(
+            QRect(390 + left, 270 + top, 31, 31)
         )
-        self._main_window.next_split_button.setGeometry(
-            QRect(
-                680 + self._main_window.LEFT_EDGE_CORRECTION,
-                270 + self._main_window.TOP_EDGE_CORRECTION,
-                31,
-                31,
-            )
+        self._main_window.next_button.setGeometry(QRect(680 + left, 270 + top, 31, 31))
+        self._main_window.pause_button.setGeometry(
+            QRect(420 + left, 560 + top, 121, 41)
         )
-        self._main_window.pause_comparison_button.setGeometry(
-            QRect(
-                420 + self._main_window.LEFT_EDGE_CORRECTION,
-                560 + self._main_window.TOP_EDGE_CORRECTION,
-                121,
-                41,
-            )
+        self._main_window.skip_button.setGeometry(QRect(485 + left, 610 + top, 56, 41))
+        self._main_window.undo_button.setGeometry(QRect(420 + left, 610 + top, 56, 41))
+        self._main_window.reset_button.setGeometry(
+            QRect(560 + left, 560 + top, 121, 91)
         )
-        self._main_window.skip_split_button.setGeometry(
-            QRect(
-                485 + self._main_window.LEFT_EDGE_CORRECTION,
-                610 + self._main_window.TOP_EDGE_CORRECTION,
-                56,
-                41,
-            )
-        )
-        self._main_window.undo_split_button.setGeometry(
-            QRect(
-                420 + self._main_window.LEFT_EDGE_CORRECTION,
-                610 + self._main_window.TOP_EDGE_CORRECTION,
-                56,
-                41,
-            )
-        )
-        self._main_window.reset_splits_button.setGeometry(
-            QRect(
-                560 + self._main_window.LEFT_EDGE_CORRECTION,
-                560 + self._main_window.TOP_EDGE_CORRECTION,
-                121,
-                91,
-            )
-        )
-        self._main_window.video_feed_display.setGeometry(
-            QRect(
-                60 + self._main_window.LEFT_EDGE_CORRECTION,
-                310 + self._main_window.TOP_EDGE_CORRECTION,
-                320,
-                240,
-            )
+        self._main_window.video_display.setGeometry(
+            QRect(60 + left, 310 + top, 320, 240)
         )
 
-        split_image_geometry = QRect(
-            390 + self._main_window.LEFT_EDGE_CORRECTION,
-            310 + self._main_window.TOP_EDGE_CORRECTION,
-            320,
-            240,
-        )
-        self._main_window.split_image_display.setGeometry(split_image_geometry)
-        self._main_window.split_image_overlay.setGeometry(split_image_geometry)
+        split_image_geometry = QRect(390 + left, 310 + top, 320, 240)
+        self._main_window.split_display.setGeometry(split_image_geometry)
+        self._main_window.split_overlay.setGeometry(split_image_geometry)
 
         self._set_nonessential_widgets_visible(True)
         self._set_button_and_label_text(truncate=True)
@@ -1433,215 +1018,79 @@ class UIController:
 
     def _set_512x288_view(self) -> None:
         """Resize and show widgets so the 512x288 display is shown."""
-        self._main_window.split_directory_line_edit.setGeometry(
-            QRect(
-                247 + self._main_window.LEFT_EDGE_CORRECTION,
-                225 + self._main_window.TOP_EDGE_CORRECTION,
-                848,
-                30,
-            )
+        left = self._main_window.LEFT_EDGE_CORRECTION
+        top = self._main_window.TOP_EDGE_CORRECTION
+        self._main_window.split_directory_box.setGeometry(
+            QRect(247 + left, 225 + top, 848, 30)
         )
-        self._main_window.video_feed_label.setGeometry(
-            QRect(
-                276 + self._main_window.LEFT_EDGE_CORRECTION,
-                272 + self._main_window.TOP_EDGE_CORRECTION,
-                80,
-                31,
-            )
-        )
+        self._main_window.video_title.setGeometry(QRect(276 + left, 272 + top, 80, 31))
         self._main_window.split_name_label.setGeometry(
-            QRect(
-                613 + self._main_window.LEFT_EDGE_CORRECTION,
-                255 + self._main_window.TOP_EDGE_CORRECTION,
-                450,
-                31,
-            )
+            QRect(613 + left, 255 + top, 450, 31)
         )
-        self._main_window.split_image_loop_label.setGeometry(
-            QRect(
-                613 + self._main_window.LEFT_EDGE_CORRECTION,
-                280 + self._main_window.TOP_EDGE_CORRECTION,
-                450,
-                31,
-            )
+        self._main_window.split_loop_label.setGeometry(
+            QRect(613 + left, 280 + top, 450, 31)
         )
-        self._main_window.current_match_percent_label.setGeometry(
-            QRect(
-                80 + self._main_window.LEFT_EDGE_CORRECTION,
-                608 + self._main_window.TOP_EDGE_CORRECTION,
-                161,
-                31,
-            )
+        self._main_window.match_percent_label.setGeometry(
+            QRect(80 + left, 608 + top, 161, 31)
         )
-        self._main_window.highest_match_percent_label.setGeometry(
-            QRect(
-                80 + self._main_window.LEFT_EDGE_CORRECTION,
-                638 + self._main_window.TOP_EDGE_CORRECTION,
-                161,
-                31,
-            )
+        self._main_window.highest_percent_label.setGeometry(
+            QRect(80 + left, 638 + top, 161, 31)
         )
-        self._main_window.threshold_match_percent_label.setGeometry(
-            QRect(
-                80 + self._main_window.LEFT_EDGE_CORRECTION,
-                668 + self._main_window.TOP_EDGE_CORRECTION,
-                161,
-                31,
-            )
+        self._main_window.threshold_percent_label.setGeometry(
+            QRect(80 + left, 668 + top, 161, 31)
         )
-        self._main_window.current_match_percent.setGeometry(
-            QRect(
-                245 + self._main_window.LEFT_EDGE_CORRECTION,
-                608 + self._main_window.TOP_EDGE_CORRECTION,
-                46,
-                31,
-            )
+        self._main_window.match_percent.setGeometry(
+            QRect(245 + left, 608 + top, 46, 31)
         )
-        self._main_window.highest_match_percent.setGeometry(
-            QRect(
-                245 + self._main_window.LEFT_EDGE_CORRECTION,
-                638 + self._main_window.TOP_EDGE_CORRECTION,
-                46,
-                31,
-            )
+        self._main_window.highest_percent.setGeometry(
+            QRect(245 + left, 638 + top, 46, 31)
         )
-        self._main_window.threshold_match_percent.setGeometry(
-            QRect(
-                245 + self._main_window.LEFT_EDGE_CORRECTION,
-                668 + self._main_window.TOP_EDGE_CORRECTION,
-                46,
-                31,
-            )
+        self._main_window.threshold_percent.setGeometry(
+            QRect(245 + left, 668 + top, 46, 31)
         )
-        self._main_window.current_match_percent_sign.setGeometry(
-            QRect(
-                300 + self._main_window.LEFT_EDGE_CORRECTION,
-                608 + self._main_window.TOP_EDGE_CORRECTION,
-                21,
-                31,
-            )
+        self._main_window.percent_sign_1.setGeometry(
+            QRect(300 + left, 608 + top, 21, 31)
         )
-        self._main_window.highest_match_percent_sign.setGeometry(
-            QRect(
-                300 + self._main_window.LEFT_EDGE_CORRECTION,
-                638 + self._main_window.TOP_EDGE_CORRECTION,
-                21,
-                31,
-            )
+        self._main_window.percent_sign_2.setGeometry(
+            QRect(300 + left, 638 + top, 21, 31)
         )
-        self._main_window.threshold_match_percent_sign.setGeometry(
-            QRect(
-                300 + self._main_window.LEFT_EDGE_CORRECTION,
-                668 + self._main_window.TOP_EDGE_CORRECTION,
-                21,
-                31,
-            )
+        self._main_window.percent_sign_3.setGeometry(
+            QRect(300 + left, 668 + top, 21, 31)
         )
-        self._main_window.split_directory_button.setGeometry(
-            QRect(
-                60 + self._main_window.LEFT_EDGE_CORRECTION,
-                225 + self._main_window.TOP_EDGE_CORRECTION,
-                180,
-                30,
-            )
+        self._main_window.split_dir_button.setGeometry(
+            QRect(60 + left, 225 + top, 180, 30)
         )
         self._main_window.minimal_view_button.setGeometry(
-            QRect(
-                60 + self._main_window.LEFT_EDGE_CORRECTION,
-                270 + self._main_window.TOP_EDGE_CORRECTION,
-                100,
-                31,
-            )
+            QRect(60 + left, 270 + top, 100, 31)
         )
         self._main_window.next_source_button.setGeometry(
-            QRect(
-                472 + self._main_window.LEFT_EDGE_CORRECTION,
-                270 + self._main_window.TOP_EDGE_CORRECTION,
-                100,
-                31,
-            )
+            QRect(472 + left, 270 + top, 100, 31)
         )
         self._main_window.screenshot_button.setGeometry(
-            QRect(
-                372 + self._main_window.LEFT_EDGE_CORRECTION,
-                608 + self._main_window.TOP_EDGE_CORRECTION,
-                171,
-                41,
-            )
+            QRect(372 + left, 608 + top, 171, 41)
         )
-        self._main_window.reload_video_button.setGeometry(
-            QRect(
-                372 + self._main_window.LEFT_EDGE_CORRECTION,
-                658 + self._main_window.TOP_EDGE_CORRECTION,
-                171,
-                41,
-            )
+        self._main_window.reconnect_button.setGeometry(
+            QRect(372 + left, 658 + top, 171, 41)
         )
-        self._main_window.previous_split_button.setGeometry(
-            QRect(
-                582 + self._main_window.LEFT_EDGE_CORRECTION,
-                270 + self._main_window.TOP_EDGE_CORRECTION,
-                31,
-                31,
-            )
+        self._main_window.previous_button.setGeometry(
+            QRect(582 + left, 270 + top, 31, 31)
         )
-        self._main_window.next_split_button.setGeometry(
-            QRect(
-                1064 + self._main_window.LEFT_EDGE_CORRECTION,
-                270 + self._main_window.TOP_EDGE_CORRECTION,
-                31,
-                31,
-            )
+        self._main_window.next_button.setGeometry(QRect(1064 + left, 270 + top, 31, 31))
+        self._main_window.pause_button.setGeometry(
+            QRect(612 + left, 608 + top, 191, 41)
         )
-        self._main_window.pause_comparison_button.setGeometry(
-            QRect(
-                612 + self._main_window.LEFT_EDGE_CORRECTION,
-                608 + self._main_window.TOP_EDGE_CORRECTION,
-                191,
-                41,
-            )
+        self._main_window.skip_button.setGeometry(QRect(712 + left, 658 + top, 91, 41))
+        self._main_window.undo_button.setGeometry(QRect(612 + left, 658 + top, 91, 41))
+        self._main_window.reset_button.setGeometry(
+            QRect(874 + left, 608 + top, 191, 91)
         )
-        self._main_window.skip_split_button.setGeometry(
-            QRect(
-                712 + self._main_window.LEFT_EDGE_CORRECTION,
-                658 + self._main_window.TOP_EDGE_CORRECTION,
-                91,
-                41,
-            )
-        )
-        self._main_window.undo_split_button.setGeometry(
-            QRect(
-                612 + self._main_window.LEFT_EDGE_CORRECTION,
-                658 + self._main_window.TOP_EDGE_CORRECTION,
-                91,
-                41,
-            )
-        )
-        self._main_window.reset_splits_button.setGeometry(
-            QRect(
-                874 + self._main_window.LEFT_EDGE_CORRECTION,
-                608 + self._main_window.TOP_EDGE_CORRECTION,
-                191,
-                91,
-            )
-        )
-        self._main_window.video_feed_display.setGeometry(
-            QRect(
-                60 + self._main_window.LEFT_EDGE_CORRECTION,
-                310 + self._main_window.TOP_EDGE_CORRECTION,
-                512,
-                288,
-            )
+        self._main_window.video_display.setGeometry(
+            QRect(60 + left, 310 + top, 512, 288)
         )
 
-        split_image_geometry = QRect(
-            582 + self._main_window.LEFT_EDGE_CORRECTION,
-            310 + self._main_window.TOP_EDGE_CORRECTION,
-            512,
-            288,
-        )
-        self._main_window.split_image_display.setGeometry(split_image_geometry)
-        self._main_window.split_image_overlay.setGeometry(split_image_geometry)
+        split_image_geometry = QRect(582 + left, 310 + top, 512, 288)
+        self._main_window.split_display.setGeometry(split_image_geometry)
+        self._main_window.split_overlay.setGeometry(split_image_geometry)
 
         self._set_nonessential_widgets_visible(True)
         self._set_button_and_label_text(truncate=False)
@@ -1649,215 +1098,79 @@ class UIController:
 
     def _set_432x243_view(self) -> None:
         """Resize and show widgets so the 432x243 display is shown."""
-        self._main_window.split_directory_line_edit.setGeometry(
-            QRect(
-                247 + self._main_window.LEFT_EDGE_CORRECTION,
-                225 + self._main_window.TOP_EDGE_CORRECTION,
-                688,
-                30,
-            )
+        left = self._main_window.LEFT_EDGE_CORRECTION
+        top = self._main_window.TOP_EDGE_CORRECTION
+        self._main_window.split_directory_box.setGeometry(
+            QRect(247 + left, 225 + top, 688, 30)
         )
-        self._main_window.video_feed_label.setGeometry(
-            QRect(
-                161 + self._main_window.LEFT_EDGE_CORRECTION,
-                272 + self._main_window.TOP_EDGE_CORRECTION,
-                231,
-                31,
-            )
-        )
+        self._main_window.video_title.setGeometry(QRect(161 + left, 272 + top, 231, 31))
         self._main_window.split_name_label.setGeometry(
-            QRect(
-                534 + self._main_window.LEFT_EDGE_CORRECTION,
-                255 + self._main_window.TOP_EDGE_CORRECTION,
-                371,
-                31,
-            )
+            QRect(534 + left, 255 + top, 371, 31)
         )
-        self._main_window.split_image_loop_label.setGeometry(
-            QRect(
-                534 + self._main_window.LEFT_EDGE_CORRECTION,
-                280 + self._main_window.TOP_EDGE_CORRECTION,
-                371,
-                31,
-            )
+        self._main_window.split_loop_label.setGeometry(
+            QRect(534 + left, 280 + top, 371, 31)
         )
-        self._main_window.current_match_percent_label.setGeometry(
-            QRect(
-                80 + self._main_window.LEFT_EDGE_CORRECTION,
-                563 + self._main_window.TOP_EDGE_CORRECTION,
-                161,
-                31,
-            )
+        self._main_window.match_percent_label.setGeometry(
+            QRect(80 + left, 563 + top, 161, 31)
         )
-        self._main_window.highest_match_percent_label.setGeometry(
-            QRect(
-                80 + self._main_window.LEFT_EDGE_CORRECTION,
-                593 + self._main_window.TOP_EDGE_CORRECTION,
-                161,
-                31,
-            )
+        self._main_window.highest_percent_label.setGeometry(
+            QRect(80 + left, 593 + top, 161, 31)
         )
-        self._main_window.threshold_match_percent_label.setGeometry(
-            QRect(
-                80 + self._main_window.LEFT_EDGE_CORRECTION,
-                623 + self._main_window.TOP_EDGE_CORRECTION,
-                161,
-                31,
-            )
+        self._main_window.threshold_percent_label.setGeometry(
+            QRect(80 + left, 623 + top, 161, 31)
         )
-        self._main_window.current_match_percent.setGeometry(
-            QRect(
-                245 + self._main_window.LEFT_EDGE_CORRECTION,
-                563 + self._main_window.TOP_EDGE_CORRECTION,
-                46,
-                31,
-            )
+        self._main_window.match_percent.setGeometry(
+            QRect(245 + left, 563 + top, 46, 31)
         )
-        self._main_window.highest_match_percent.setGeometry(
-            QRect(
-                245 + self._main_window.LEFT_EDGE_CORRECTION,
-                593 + self._main_window.TOP_EDGE_CORRECTION,
-                46,
-                31,
-            )
+        self._main_window.highest_percent.setGeometry(
+            QRect(245 + left, 593 + top, 46, 31)
         )
-        self._main_window.threshold_match_percent.setGeometry(
-            QRect(
-                245 + self._main_window.LEFT_EDGE_CORRECTION,
-                623 + self._main_window.TOP_EDGE_CORRECTION,
-                46,
-                31,
-            )
+        self._main_window.threshold_percent.setGeometry(
+            QRect(245 + left, 623 + top, 46, 31)
         )
-        self._main_window.current_match_percent_sign.setGeometry(
-            QRect(
-                300 + self._main_window.LEFT_EDGE_CORRECTION,
-                563 + self._main_window.TOP_EDGE_CORRECTION,
-                21,
-                31,
-            )
+        self._main_window.percent_sign_1.setGeometry(
+            QRect(300 + left, 563 + top, 21, 31)
         )
-        self._main_window.highest_match_percent_sign.setGeometry(
-            QRect(
-                300 + self._main_window.LEFT_EDGE_CORRECTION,
-                593 + self._main_window.TOP_EDGE_CORRECTION,
-                21,
-                31,
-            )
+        self._main_window.percent_sign_2.setGeometry(
+            QRect(300 + left, 593 + top, 21, 31)
         )
-        self._main_window.threshold_match_percent_sign.setGeometry(
-            QRect(
-                300 + self._main_window.LEFT_EDGE_CORRECTION,
-                623 + self._main_window.TOP_EDGE_CORRECTION,
-                21,
-                31,
-            )
+        self._main_window.percent_sign_3.setGeometry(
+            QRect(300 + left, 623 + top, 21, 31)
         )
-        self._main_window.split_directory_button.setGeometry(
-            QRect(
-                60 + self._main_window.LEFT_EDGE_CORRECTION,
-                225 + self._main_window.TOP_EDGE_CORRECTION,
-                180,
-                30,
-            )
+        self._main_window.split_dir_button.setGeometry(
+            QRect(60 + left, 225 + top, 180, 30)
         )
         self._main_window.minimal_view_button.setGeometry(
-            QRect(
-                60 + self._main_window.LEFT_EDGE_CORRECTION,
-                270 + self._main_window.TOP_EDGE_CORRECTION,
-                100,
-                31,
-            )
+            QRect(60 + left, 270 + top, 100, 31)
         )
         self._main_window.next_source_button.setGeometry(
-            QRect(
-                392 + self._main_window.LEFT_EDGE_CORRECTION,
-                270 + self._main_window.TOP_EDGE_CORRECTION,
-                100,
-                31,
-            )
+            QRect(392 + left, 270 + top, 100, 31)
         )
         self._main_window.screenshot_button.setGeometry(
-            QRect(
-                332 + self._main_window.LEFT_EDGE_CORRECTION,
-                563 + self._main_window.TOP_EDGE_CORRECTION,
-                131,
-                41,
-            )
+            QRect(332 + left, 563 + top, 131, 41)
         )
-        self._main_window.reload_video_button.setGeometry(
-            QRect(
-                332 + self._main_window.LEFT_EDGE_CORRECTION,
-                613 + self._main_window.TOP_EDGE_CORRECTION,
-                131,
-                41,
-            )
+        self._main_window.reconnect_button.setGeometry(
+            QRect(332 + left, 613 + top, 131, 41)
         )
-        self._main_window.previous_split_button.setGeometry(
-            QRect(
-                502 + self._main_window.LEFT_EDGE_CORRECTION,
-                270 + self._main_window.TOP_EDGE_CORRECTION,
-                31,
-                31,
-            )
+        self._main_window.previous_button.setGeometry(
+            QRect(502 + left, 270 + top, 31, 31)
         )
-        self._main_window.next_split_button.setGeometry(
-            QRect(
-                904 + self._main_window.LEFT_EDGE_CORRECTION,
-                270 + self._main_window.TOP_EDGE_CORRECTION,
-                31,
-                31,
-            )
+        self._main_window.next_button.setGeometry(QRect(904 + left, 270 + top, 31, 31))
+        self._main_window.pause_button.setGeometry(
+            QRect(532 + left, 563 + top, 181, 41)
         )
-        self._main_window.pause_comparison_button.setGeometry(
-            QRect(
-                532 + self._main_window.LEFT_EDGE_CORRECTION,
-                563 + self._main_window.TOP_EDGE_CORRECTION,
-                181,
-                41,
-            )
+        self._main_window.skip_button.setGeometry(QRect(627 + left, 613 + top, 86, 41))
+        self._main_window.undo_button.setGeometry(QRect(532 + left, 613 + top, 86, 41))
+        self._main_window.reset_button.setGeometry(
+            QRect(724 + left, 563 + top, 181, 91)
         )
-        self._main_window.skip_split_button.setGeometry(
-            QRect(
-                627 + self._main_window.LEFT_EDGE_CORRECTION,
-                613 + self._main_window.TOP_EDGE_CORRECTION,
-                86,
-                41,
-            )
-        )
-        self._main_window.undo_split_button.setGeometry(
-            QRect(
-                532 + self._main_window.LEFT_EDGE_CORRECTION,
-                613 + self._main_window.TOP_EDGE_CORRECTION,
-                86,
-                41,
-            )
-        )
-        self._main_window.reset_splits_button.setGeometry(
-            QRect(
-                724 + self._main_window.LEFT_EDGE_CORRECTION,
-                563 + self._main_window.TOP_EDGE_CORRECTION,
-                181,
-                91,
-            )
-        )
-        self._main_window.video_feed_display.setGeometry(
-            QRect(
-                60 + self._main_window.LEFT_EDGE_CORRECTION,
-                310 + self._main_window.TOP_EDGE_CORRECTION,
-                432,
-                243,
-            )
+        self._main_window.video_display.setGeometry(
+            QRect(60 + left, 310 + top, 432, 243)
         )
 
-        split_image_geometry = QRect(
-            502 + self._main_window.LEFT_EDGE_CORRECTION,
-            310 + self._main_window.TOP_EDGE_CORRECTION,
-            432,
-            243,
-        )
-        self._main_window.split_image_display.setGeometry(split_image_geometry)
-        self._main_window.split_image_overlay.setGeometry(split_image_geometry)
+        split_image_geometry = QRect(502 + left, 310 + top, 432, 243)
+        self._main_window.split_display.setGeometry(split_image_geometry)
+        self._main_window.split_overlay.setGeometry(split_image_geometry)
 
         self._set_nonessential_widgets_visible(True)
         self._set_button_and_label_text(truncate=False)
@@ -1878,43 +1191,23 @@ class UIController:
 
         if truncate:
             self._main_window.screenshot_button.setText("Screenshot")
-            self._main_window.current_match_percent_label.setText("Sim:")
-            self._main_window.highest_match_percent_label.setText("High:")
-            self._main_window.threshold_match_percent_label.setText("Thr:")
-            if self._splitter.suspended:
-                self._main_window.pause_comparison_button.setText(
-                    self._main_window.pause_comparison_button_unpause_text_truncated
-                )
-            else:
-                self._main_window.pause_comparison_button.setText(
-                    self._main_window.pause_comparison_button_pause_text_truncated
-                )
-            self._main_window.undo_split_button.setText("Undo")
-            self._main_window.skip_split_button.setText("Skip")
-            self._main_window.reset_splits_button.setText("Reset")
+            self._main_window.match_percent_label.setText("Sim:")
+            self._main_window.highest_percent_label.setText("High:")
+            self._main_window.threshold_percent_label.setText("Thr:")
+            self._main_window.undo_button.setText("Undo")
+            self._main_window.skip_button.setText("Skip")
+            self._main_window.reset_button.setText("Reset")
 
         else:
             self._main_window.screenshot_button.setText("Take screenshot")
-            self._main_window.current_match_percent_label.setText(
-                "Similarity to split image:"
-            )
-            self._main_window.highest_match_percent_label.setText(
+            self._main_window.match_percent_label.setText("Similarity to split image:")
+            self._main_window.highest_percent_label.setText(
                 "Highest similarity so far:"
             )
-            self._main_window.threshold_match_percent_label.setText(
-                "Threshold similarity:"
-            )
-            if self._splitter.suspended:
-                self._main_window.pause_comparison_button.setText(
-                    self._main_window.pause_comparison_button_unpause_text_default
-                )
-            else:
-                self._main_window.pause_comparison_button.setText(
-                    self._main_window.pause_comparison_button_pause_text_default
-                )
-            self._main_window.undo_split_button.setText("Undo split")
-            self._main_window.skip_split_button.setText("Skip split")
-            self._main_window.reset_splits_button.setText("Reset splits")
+            self._main_window.threshold_percent_label.setText("Threshold similarity:")
+            self._main_window.undo_button.setText("Undo split")
+            self._main_window.skip_button.setText("Skip split")
+            self._main_window.reset_button.setText("Reset splits")
 
     def _set_nonessential_widgets_visible(self, visible: bool) -> None:
         """Set widget visibility according to minimal view status.
@@ -1923,39 +1216,274 @@ class UIController:
             visible (bool): If True, show all non-minimal-view widgets. If
                 False, hide all non-minimal-view widgets.
         """
-        self._main_window.split_directory_line_edit.setVisible(visible)
-        self._main_window.split_directory_button.setVisible(visible)
+        self._main_window.split_directory_box.setVisible(visible)
+        self._main_window.split_dir_button.setVisible(visible)
         self._main_window.next_source_button.setVisible(visible)
         self._main_window.screenshot_button.setVisible(visible)
-        self._main_window.reload_video_button.setVisible(visible)
-        self._main_window.video_feed_display.setVisible(visible)
-        self._main_window.split_image_display.setVisible(visible)
+        self._main_window.reconnect_button.setVisible(visible)
+        self._main_window.video_display.setVisible(visible)
+        self._main_window.split_display.setVisible(visible)
         # Only display this when the other widgets are hidden
-        self._main_window.minimal_view_no_splits_label.setVisible(not visible)
+        self._main_window.split_info_min_label.setVisible(not visible)
 
-    #################################
-    #                               #
-    # Update UI, Handle Key Presses #
-    #                               #
-    #################################
+    ###########################
+    #                         #
+    # Update UI from Splitter #
+    #                         #
+    ###########################
 
-    def _update_ui(self) -> None:
-        """Read values from the splitter and use them to update the UI; also
-        read inputs from the user and use them to update the UI and the
-        splitter.
+    def _update_from_splitter(self) -> None:
+        """Read values from the splitter and use them to update the UI."""
+        self._update_video_feed()
+        self._update_video_title()
+        self._update_split_image_labels()
+        self._update_split_overlay()
+        self._update_match_percents()
+        self._update_pause_button()
+        self._set_buttons_and_hotkeys_enabled()
 
-        Since this method is called many times per second, most of its method
-        calls are wrapped in if statements. This diminishes readability
-        significantly, but also cuts down so much on CPU usage that I thought
-        it was worth it.
+    def _update_video_feed(self) -> None:
+        """Clear video if video is down; update video if video is alive."""
+        if settings.get_bool("SHOW_MIN_VIEW"):
+            return
+
+        video_alive = self._splitter.capture_thread.is_alive()
+        video = self._main_window.video_display
+
+        # Video not connected, but video frame on UI
+        if video.text() == "" and not video_alive:
+            video.setText(self._main_window.video_display_txt)
+        # Video is connected, but is not showing on UI
+        elif self._splitter.frame_pixmap is not None:
+            video.setPixmap(self._splitter.frame_pixmap)
+
+    def _update_video_title(self) -> None:
+        """Adjust video title depending on whether video is alive."""
+        video_alive = self._splitter.capture_thread.is_alive()
+        norm_live_txt = self._main_window.video_live_txt
+        norm_down_txt = self._main_window.video_down_txt
+        min_down_txt = self._main_window.min_video_down_txt
+        min_live_txt = self._main_window.min_video_live_txt
+        label = self._main_window.video_title
+
+        if settings.get_bool("SHOW_MIN_VIEW"):
+            # Video is connected, but label says it's not
+            if video_alive and label.text() != min_live_txt:
+                label.setText(min_live_txt)
+            # Video isn't conected, but label says it is
+            elif not video_alive and label.text() != min_down_txt:
+                label.setText(min_down_txt)
+
+        else:
+            # Video is connected, but label says it's not
+            if video_alive and label.text() != norm_live_txt:
+                label.setText(norm_live_txt)
+            # Video isn't connected, but label says it is
+            elif not video_alive and label.text() != norm_down_txt:
+                label.setText(norm_down_txt)
+
+    def _update_split_image_labels(self) -> None:
+        """Update split name, loops, and image."""
+        current_index = self._splitter.splits.current_image_index
+        current_loop = self._splitter.splits.current_loop
+        split_display = self._main_window.split_display
+        split_label = self._main_window.split_name_label
+        loop_label = self._main_window.split_loop_label
+        splits_down_txt = self._main_window.split_display_txt
+        splits_min_label = self._main_window.split_info_min_label
+
+        # No splits loaded, but UI showing split image
+        if current_index is None and split_display.text() != splits_down_txt:
+            split_display.setText(splits_down_txt)
+            split_label.setText("")
+            loop_label.setText("")
+            splits_min_label.setText(splits_down_txt)
+            splits_min_label.raise_()
+
+        # UI showing split but split has been changed, resized, or reset
+        elif self._redraw_split_labels:
+            self._redraw_split_labels = False
+            current_split_image = self._splitter.splits.list[current_index]
+
+            if not settings.get_bool("SHOW_MIN_VIEW"):
+                split_display.setPixmap(current_split_image.pixmap)
+
+            elided_name = split_label.fontMetrics().elidedText(
+                current_split_image.name, Qt.ElideRight, split_label.width()
+            )
+            split_label.setText(elided_name)
+
+            splits_min_label.setText("")
+            splits_min_label.lower()
+
+            total_loops = current_split_image.loops
+            if total_loops == 0:
+                loop_label.setText("Split does not loop")
+            else:
+                loop_label.setText(f"Loop {current_loop} of {total_loops}")
+
+    def _update_split_overlay(self) -> None:
+        """Show split overlay with countdown before and after splitting."""
+        overlay = self._main_window.split_overlay
+        delay_txt = self._main_window.overlay_delay_txt
+        pause_txt = self._main_window.overlay_pause_txt
+
+        # Splitter is delaying pre-split
+        if self._splitter.delaying and self._splitter.delay_remaining is not None:
+            overlay.setVisible(True)
+            overlay.setText(delay_txt.format(amount=self._splitter.delay_remaining))
+
+        # Splitter is pausing post-split
+        elif self._splitter.suspended and self._splitter.suspend_remaining is not None:
+            overlay.setVisible(True)
+            overlay.setText(pause_txt.format(amount=self._splitter.suspend_remaining))
+
+        # Splitter isn't pausing or delaying, but the overlay is showing
+        elif overlay.text() != "":
+            overlay.setVisible(False)
+            overlay.setText("")
+
+    def _update_match_percents(self):
+        """Update match percents or set them to blank."""
+        decimals = settings.get_int("MATCH_PERCENT_DECIMALS")
+        format_str = f"{{:.{decimals}f}}"
+        null_str = self._null_match_percent_string(decimals)
+        match_percent = self._splitter.match_percent
+        match_label = self._main_window.match_percent
+        high_percent = self._splitter.highest_percent
+        high_label = self._main_window.highest_percent
+        current_index = self._splitter.splits.current_image_index
+        thresh_label = self._main_window.threshold_percent
+
+        # Splitter isn't comparing images, but UI is showing current%, highest%
+        if match_percent is None or high_percent is None:
+            if match_label.text() != null_str or high_label != null_str:
+                match_label.setText(null_str)
+                high_label.setText(null_str)
+
+        # Update current match%, highest%
+        else:
+            match_label.setText(format_str.format(match_percent * 100))
+            high_label.setText(format_str.format(high_percent * 100))
+
+        # No splits loaded, but UI is showing threshold%
+        if current_index is None and thresh_label.text() != null_str:
+            thresh_label.setText(null_str)
+
+        # Update threshold%
+        elif current_index is not None:
+            thresh_percent = self._splitter.splits.list[current_index].threshold
+            thresh_label.setText(format_str.format(thresh_percent * 100))
+
+    def _update_pause_button(self):
+        """Adjust the length and content of the pause button's text according
+        to aspect ratio and splitter status.
         """
-        self._update_label_and_button_text()
+        suspended = self._splitter.suspended
+        pause_button = self._main_window.pause_button
+        show_short_text = (
+            settings.get_bool("SHOW_MIN_VIEW")
+            or settings.get_str("ASPECT_RATIO") == "4:3 (320x240)"
+        )
+
+        if show_short_text:
+            if suspended:
+                pause_button.setText(self._main_window.unpause_short_txt)
+            else:
+                pause_button.setText(self._main_window.pause_short_txt)
+
+        else:
+            if suspended:
+                pause_button.setText(self._main_window.unpause_long_txt)
+            else:
+                pause_button.setText(self._main_window.pause_long_txt)
+
+    def _set_buttons_and_hotkeys_enabled(self) -> bool:
+        """Enable and disable hotkeys and buttons depending on whether splits
+        are alive, the video is alive, and the current split is the first or
+        last split."""
+        current_split_index = self._splitter.splits.current_image_index
+        video_alive = self._splitter.capture_thread.is_alive()
+
+        if current_split_index is None:
+            # Enable screenshots if video is on
+            if video_alive:
+                self._main_window.screenshot_button.setEnabled(True)
+            else:
+                self._main_window.screenshot_button.setEnabled(False)
+
+            # Disable split, undo, skip, previous, next split, pause
+            self._split_hotkey_enabled = False
+            self._undo_hotkey_enabled = False
+            self._skip_hotkey_enabled = False
+            self._main_window.undo_button.setEnabled(False)
+            self._main_window.skip_button.setEnabled(False)
+            self._main_window.previous_button.setEnabled(False)
+            self._main_window.next_button.setEnabled(False)
+            self._main_window.pause_button.setEnabled(False)
+
+        else:
+            loop = self._splitter.splits.current_loop
+            total_loops = self._splitter.splits.list[current_split_index].loops
+            total_splits = len(self._splitter.splits.list) - 1
+
+            # Enable split hotkey
+            self._split_hotkey_enabled = True
+
+            # Enable screenshots if video is on
+            if video_alive:
+                self._main_window.screenshot_button.setEnabled(True)
+                self._main_window.pause_button.setEnabled(True)
+            else:
+                self._main_window.screenshot_button.setEnabled(False)
+                self._main_window.pause_button.setEnabled(False)
+
+            # Enable undo and previous if this isn't the first split
+            if current_split_index == 0 and loop == 0:
+                self._undo_hotkey_enabled = False
+                self._main_window.undo_button.setEnabled(False)
+                self._main_window.previous_button.setEnabled(False)
+            else:
+                self._undo_hotkey_enabled = True
+                self._main_window.undo_button.setEnabled(True)
+                self._main_window.previous_button.setEnabled(True)
+
+            # Enable skip and next if this isn't the last split
+            if current_split_index == total_splits and loop == total_loops:
+                self._skip_hotkey_enabled = False
+                self._main_window.skip_button.setEnabled(False)
+                self._main_window.next_button.setEnabled(False)
+            else:
+                self._skip_hotkey_enabled = True
+                self._main_window.skip_button.setEnabled(True)
+                self._main_window.next_button.setEnabled(True)
+
+    def _null_match_percent_string(self, decimals: int) -> None:
+        """Return a string representing a blank match percent with the number
+        of decimal places the user chooses in settings.
+
+        Returns:
+            str: The null match percent string. Possible return values are
+            "--", "--.-", and "--.--".
+        """
+        match_percent_string = "--"
+        if decimals > 0:
+            match_percent_string += "."
+            while decimals > 0:
+                match_percent_string += "-"
+                decimals -= 1
+        return match_percent_string
+
+    ###########################
+    #                         #
+    # Update UI from Keyboard #
+    #                         #
+    ###########################
+
+    def _update_from_keyboard(self) -> None:
+        """Use flags set in _handle_key_press to split and do other actions."""
         self._handle_hotkey_press()
         self._execute_split_action()
-
-        splitter_flags_changed = self._update_flags()
-        if splitter_flags_changed:
-            self._set_buttons_and_hotkeys_enabled()
 
     def _handle_key_press(self, key: keyboard.Key) -> None:
         """Process key presses, setting flags if the key is a hotkey.
@@ -1982,25 +1510,25 @@ class UIController:
             key_name, key_code = str(key).replace("Key.", ""), key.value.vk
 
         # Use #1 (set hotkey settings in settings window)
-        for hotkey_line_edit in [
-            self._settings_window.split_hotkey_line_edit,
-            self._settings_window.reset_hotkey_line_edit,
-            self._settings_window.pause_hotkey_line_edit,
-            self._settings_window.undo_split_hotkey_line_edit,
-            self._settings_window.skip_split_hotkey_line_edit,
-            self._settings_window.previous_split_hotkey_line_edit,
-            self._settings_window.next_split_hotkey_line_edit,
-            self._settings_window.screenshot_hotkey_line_edit,
-            self._settings_window.toggle_global_hotkeys_hotkey_line_edit,
+        for hotkey_box in [
+            self._settings_window.split_hotkey_box,
+            self._settings_window.reset_hotkey_box,
+            self._settings_window.pause_hotkey_box,
+            self._settings_window.undo_hotkey_box,
+            self._settings_window.skip_hotkey_box,
+            self._settings_window.previous_hotkey_box,
+            self._settings_window.next_hotkey_box,
+            self._settings_window.screenshot_hotkey_box,
+            self._settings_window.toggle_global_hotkeys_hotkey_box,
         ]:
-            if hotkey_line_edit.hasFocus():
-                hotkey_line_edit.setText(key_name)
-                hotkey_line_edit.key_code = key_code
+            if hotkey_box.hasFocus():
+                hotkey_box.setText(key_name)
+                hotkey_box.key_code = key_code
                 return
 
         # Use #2 (set "hotkey pressed" flag for _handle_hotkey_press)
-        if not self._settings_window_showing:
-            for hotkey_flag, settings_string in {
+        if not self._settings_window.isVisible():
+            for hotkey_pressed, settings_string in {
                 "_split_hotkey_pressed": "SPLIT_HOTKEY_CODE",
                 "_reset_hotkey_pressed": "RESET_HOTKEY_CODE",
                 "_undo_hotkey_pressed": "UNDO_HOTKEY_CODE",
@@ -2012,7 +1540,7 @@ class UIController:
             }.items():
                 if str(key_code) == settings.get_str(settings_string):
                     # Use setattr because that allows us to use this dict format
-                    setattr(self, hotkey_flag, True)
+                    setattr(self, hotkey_pressed, True)
 
     def _handle_hotkey_press(self) -> None:
         """React to the flags set in _handle_key_press.
@@ -2030,84 +1558,48 @@ class UIController:
         feel that the alternative of having everything laid out in if-blocks
         was worse.
         """
-        # This value is used frequently, so I define it once here for simplicity
         global_hotkeys_enabled = settings.get_bool("GLOBAL_HOTKEYS_ENABLED")
+        if self._toggle_hotkeys_hotkey_pressed:
+            self._toggle_hotkeys_hotkey_pressed = False
+            settings.set_value("GLOBAL_HOTKEYS_ENABLED", not global_hotkeys_enabled)
+            return
 
-        # Call the hotkey's action if it's set
-        for flags, action in {
-            # Split hotkey
-            (
-                self._split_hotkey_pressed,
-                "_split_hotkey_pressed",
-                self._split_hotkey_enabled,
-            ): self._request_next_split,
-            # Reset hotkey
-            (
-                self._reset_hotkey_pressed,
-                "_reset_hotkey_pressed",
-                True,
-            ): self._request_reset_splits,
-            # Undo hotkey
-            (
-                self._undo_hotkey_pressed,
-                "_undo_hotkey_pressed",
-                self._undo_hotkey_enabled,
-            ): self._request_previous_split,
-            # Skip hotkey
-            (
-                self._skip_hotkey_pressed,
-                "_skip_hotkey_pressed",
-                self._skip_hotkey_enabled,
-            ): self._request_next_split,
-            # Previous split hotkey
-            (
-                self._previous_hotkey_pressed,
-                "_previous_hotkey_pressed",
-                True,
-            ): self._main_window.previous_split_button.click,
-            # Next split hotkey
-            (
-                self._next_hotkey_pressed,
-                "_next_hotkey_pressed",
-                True,
-            ): self._main_window.next_split_button.click,
-            # Screenshot hotkey
-            (
-                self._screenshot_hotkey_pressed,
-                "_screenshot_hotkey_pressed",
-                True,
-            ): self._main_window.screenshot_button.click,
-            # Toggle globals hotkey
-            (
-                self._toggle_hotkeys_hotkey_pressed,
-                "_toggle_hotkeys_hotkey_pressed",
-                True,
-            ): lambda: settings.set_value(
-                "GLOBAL_HOTKEYS_ENABLED", not global_hotkeys_enabled
-            ),
-        }.items():
+        hotkey_press_allowed = (
+            global_hotkeys_enabled or self._application.focusWindow() is not None
+        )
+        if not hotkey_press_allowed:
+            return
 
-            # If "hotkey is pressed" flag is True
-            if flags[0]:
+        if self._split_hotkey_pressed:
+            if self._split_hotkey_enabled:
+                self._request_next_split()
+            self._split_hotkey_pressed = False
 
-                # If the hotkey is allowed to be pressed
-                # (see _set_buttons_and_hotkeys_enabled)
-                if flags[2] and (
-                    # Global hotkeys enabled, OR the program is in focus
-                    # Also allow an exception for the toggle global hotkeys
-                    # key, which should be toggleable whether the app is in
-                    # focus or not.
-                    global_hotkeys_enabled
-                    or self._application.focusWindow() is not None
-                    or flags[1] == "_toggle_hotkeys_hotkey_pressed"
-                ):
+        elif self._reset_hotkey_pressed:
+            self._request_reset_splits()
+            self._reset_hotkey_pressed = False
 
-                    # Do the hotkey's associated action
-                    action()
+        elif self._undo_hotkey_pressed:
+            if self._undo_hotkey_enabled:
+                self._request_previous_split()
+            self._undo_hotkey_pressed = False
 
-                # Set "hotkey is pressed" flag to False
-                setattr(self, flags[1], False)
-                return
+        elif self._skip_hotkey_pressed:
+            if self._skip_hotkey_enabled:
+                self._request_next_split()
+            self._reset_hotkey_pressed = False
+
+        elif self._previous_hotkey_pressed:
+            self._main_window.previous_button.click()
+            self._previous_hotkey_pressed = False
+
+        elif self._next_hotkey_pressed:
+            self._main_window.next_button.click()
+            self._next_hotkey_pressed = False
+
+        elif self._screenshot_hotkey_pressed:
+            self._main_window.screenshot_button.click()
+            self._screenshot_hotkey_pressed = False
 
     def _press_hotkey(self, key_code: str) -> None:
         """Press and release a hotkey.
@@ -2151,406 +1643,9 @@ class UIController:
             # If key didn't get pressed, OR if it did get pressed but global
             # hotkeys are off and the app isn't in focus, move the split image
             # forward, since pressing the key on its own won't do that
-            if len(key_code) == 0 or (
+            hotkey_not_caught = (
                 self._application.focusWindow() is None
                 and not settings.get_bool("GLOBAL_HOTKEYS_ENABLED")
-            ):
+            )
+            if len(key_code) == 0 or hotkey_not_caught:
                 self._request_next_split()
-
-    def _update_label_and_button_text(self) -> None:
-        """Update label and button text in the UI based on splitter state."""
-        # This value is used frequently, so I define it once for readability
-        min_view_showing = settings.get_bool("SHOW_MIN_VIEW")
-
-        # Video feed
-        if min_view_showing:
-            pass
-        else:
-            # Video is down but looks up
-            if (
-                self._main_window.video_feed_display.text() == ""
-                and not self._splitter.capture_thread.is_alive()
-            ):
-                self._main_window.video_feed_display.setText(
-                    self._main_window.video_feed_display_default_text
-                )
-            # Video is up but looks down
-            elif self._splitter.frame_pixmap is not None:
-                self._main_window.video_feed_display.setPixmap(
-                    self._splitter.frame_pixmap
-                )
-
-        # Video label
-        if min_view_showing:
-            # Video feed is live, but says it is down / is blank
-            if (
-                self._splitter.capture_thread.is_alive()
-                and self._main_window.video_feed_label.text()
-                != self._main_window.video_feed_label_live_text_min
-            ):
-                self._main_window.video_feed_label.setText(
-                    self._main_window.video_feed_label_live_text_min
-                )
-            # Video feed is down, but says it is live / is blank
-            elif (
-                not self._splitter.capture_thread.is_alive()
-                and self._main_window.video_feed_label.text()
-                != self._main_window.video_feed_label_down_text_min
-            ):
-                self._main_window.video_feed_label.setText(
-                    self._main_window.video_feed_label_down_text_min
-                )
-        else:
-            # Video feed is live, but the label is wrong / blank
-            if (
-                self._splitter.capture_thread.is_alive()
-                and self._main_window.video_feed_label.text()
-                != self._main_window.video_feed_label_live_text
-            ):
-                self._main_window.video_feed_label.setText(
-                    self._main_window.video_feed_label_live_text
-                )
-            # Video feed is down, but label is filled
-            elif (
-                not self._splitter.capture_thread.is_alive()
-                and self._main_window.video_feed_label.text() != ""
-            ):
-                self._main_window.video_feed_label.setText("")
-
-        # Split image, name, and loop count
-        current_image_index = self._splitter.splits.current_image_index
-        # No split image loaded, but split image still being displayed
-        if (
-            current_image_index is None
-            and self._main_window.split_name_label.text()
-            != self._main_window.split_image_default_text
-        ):
-            self._most_recent_split_index = None
-            self._most_recent_loop = None
-
-            self._main_window.split_image_display.setText(
-                self._main_window.split_image_default_text
-            )
-            self._main_window.split_name_label.setText("")
-            self._main_window.split_image_loop_label.setText("")
-            self._main_window.minimal_view_no_splits_label.setText(
-                self._main_window.split_image_default_text
-            )
-            # Make sure this label shows over other split image labels
-            self._main_window.minimal_view_no_splits_label.raise_()
-        # Split image loaded that is either different from most recent one or on a different loop
-        elif (
-            current_image_index is not None
-            and (
-                current_image_index != self._most_recent_split_index
-                or self._splitter.splits.current_loop != self._most_recent_loop
-            )
-            or self._redraw_split_labels  # Set by various methods
-        ):
-            self._most_recent_split_index = current_image_index
-            self._most_recent_loop = self._splitter.splits.current_loop
-
-            self._redraw_split_labels = False
-
-            if min_view_showing:
-                pass
-            else:
-                self._main_window.split_image_display.setPixmap(
-                    self._splitter.splits.list[self._most_recent_split_index].pixmap
-                )
-
-            split_name = self._splitter.splits.list[self._most_recent_split_index].name
-            elided_name = self._main_window.split_name_label.fontMetrics().elidedText(
-                split_name, Qt.ElideRight, self._main_window.split_name_label.width()
-            )
-            self._main_window.split_name_label.setText(elided_name)
-            self._main_window.minimal_view_no_splits_label.setText("")
-            # Make sure this label doesn't block other labels
-            self._main_window.minimal_view_no_splits_label.lower()
-
-            current_total_loops = self._splitter.splits.list[
-                self._most_recent_split_index
-            ].loops
-            if current_total_loops == 0:
-                self._main_window.split_image_loop_label.setText("Split does not loop")
-            else:
-                self._main_window.split_image_loop_label.setText(
-                    f"Loop {self._splitter.splits.current_loop} of {current_total_loops}"
-                )
-
-        # Split image overlay
-        if self._splitter.delaying and self._splitter.delay_remaining is not None:
-            self._main_window.split_image_overlay.setVisible(True)
-            self._main_window.split_image_overlay.setText(
-                "Splitting in {amount:.1f} s".format(
-                    amount=self._splitter.delay_remaining
-                )
-            )
-        elif self._splitter.suspended and self._splitter.suspend_remaining is not None:
-            self._main_window.split_image_overlay.setVisible(True)
-            self._main_window.split_image_overlay.setText(
-                "Paused for next {amount:.1f} s".format(
-                    amount=self._splitter.suspend_remaining
-                )
-            )
-        elif self._main_window.split_image_overlay.text() != "":
-            self._main_window.split_image_overlay.setVisible(False)
-            self._main_window.split_image_overlay.setText("")
-
-        # This value is frequently used below, so I declare it here.
-        decimals = settings.get_int("MATCH_PERCENT_DECIMALS")
-        if self._most_recent_match_percent_decimals != decimals:
-            self._most_recent_match_percent_decimals = decimals
-            self._most_recent_match_percent_format_string = (
-                f"{{:.{self._most_recent_match_percent_decimals}f}}"
-            )
-            self._most_recent_match_percent_null_string = (
-                self._null_match_percent_string()
-            )
-
-        # Current match percent
-        if self._splitter.current_match_percent is None:
-            # Match percent is None, but UI is still showing a number
-            if (
-                self._main_window.current_match_percent.text()
-                != self._most_recent_match_percent_null_string
-            ):
-                self._main_window.current_match_percent.setText(
-                    self._most_recent_match_percent_null_string
-                )
-        else:
-            self._main_window.current_match_percent.setText(
-                self._most_recent_match_percent_format_string.format(
-                    self._splitter.current_match_percent * 100
-                )
-            )
-
-        # Highest match percent
-        if self._splitter.highest_match_percent is None:
-            # Match percent is None, but UI is still showing a number
-            if (
-                self._main_window.highest_match_percent.text()
-                != self._most_recent_match_percent_null_string
-            ):
-                self._main_window.highest_match_percent.setText(
-                    self._most_recent_match_percent_null_string
-                )
-        else:
-            self._main_window.highest_match_percent.setText(
-                self._most_recent_match_percent_format_string.format(
-                    self._splitter.highest_match_percent * 100
-                )
-            )
-
-        # Threshold match percent
-        # Make sure the splits list isn't empty before trying to access it
-        if self._most_recent_split_index is None:
-            # Match percent is blank, but UI is still showing a number
-            if (
-                self._main_window.threshold_match_percent.text()
-                != self._most_recent_match_percent_null_string
-            ):
-                self._main_window.threshold_match_percent.setText(
-                    self._most_recent_match_percent_null_string
-                )
-        else:
-            threshold_match_percent = self._splitter.splits.list[
-                self._most_recent_split_index
-            ].threshold
-            self._main_window.threshold_match_percent.setText(
-                self._most_recent_match_percent_format_string.format(
-                    threshold_match_percent * 100
-                )
-            )
-
-        # Pause / unpause button text
-        if self._splitter_suspended != self._splitter.suspended:
-            self._splitter_suspended = self._splitter.suspended
-            self._toggle_pause_comparison_button_text()
-
-    def _toggle_pause_comparison_button_text(self) -> None:
-        """Adjust the length and content of the pause button's text according
-        to aspect ratio and splitter status.
-        """
-        if (
-            settings.get_bool("SHOW_MIN_VIEW")
-            or settings.get_str("ASPECT_RATIO") == "4:3 (320x240)"
-        ):
-            if self._splitter_suspended:
-                self._main_window.pause_comparison_button.setText(
-                    self._main_window.pause_comparison_button_unpause_text_truncated
-                )
-            else:
-                self._main_window.pause_comparison_button.setText(
-                    self._main_window.pause_comparison_button_pause_text_truncated
-                )
-
-        else:
-            if self._splitter_suspended:
-                self._main_window.pause_comparison_button.setText(
-                    self._main_window.pause_comparison_button_unpause_text_default
-                )
-            else:
-                self._main_window.pause_comparison_button.setText(
-                    self._main_window.pause_comparison_button_pause_text_default
-                )
-
-    def _update_flags(self) -> bool:
-        """Check the splitter to see if certain states have changed since the
-        last check.
-
-        The following states are checked:
-            video_active: Whether `splitter.capture_thread` is alive.
-            splits_active: Whether `self.most_recent_split_index` is None. That
-                value is set by _update_label_and_button_text, which is called
-                just before this method.
-            first_split_active: Whether the current split is the first split
-                (if there is a current split). This means a split image is
-                active, it's the first split image, and it's the first loop of
-                the image.
-            last_split_active: Whether the current split is the last split (if
-                there is a current split). This means a split image is active,
-                it's the last split image, and it's the last loop of the image.
-
-        Returns:
-            flag_changed (bool): True if any of the above flags were set or
-                unset, False otherwise.
-        """
-        flag_changed = False
-
-        # video_active
-        if self._video_active != self._splitter.capture_thread.is_alive():
-            self._video_active = self._splitter.capture_thread.is_alive()
-            flag_changed = True
-
-        # splits_active
-        # Explicitly say "is not True", "is not False" on these last three
-        # flags to catch None values from __init__()
-        if self._most_recent_split_index is None:
-            if self._splits_active is not False:
-                self._splits_active = False
-                flag_changed = True
-        else:
-            if self._splits_active is not True:
-                self._splits_active = True
-                flag_changed = True
-
-        # first_split_active
-        if (
-            self._most_recent_split_index == 0
-            and self._splitter.splits.current_loop == 0
-        ):
-            if self._first_split_active is not True:
-                self._first_split_active = True
-                flag_changed = True
-        else:
-            if self._first_split_active is not False:
-                self._first_split_active = False
-                flag_changed = True
-
-        # last_split_active
-        if (
-            self._splits_active
-            and self._most_recent_split_index == len(self._splitter.splits.list) - 1
-            and self._splitter.splits.current_loop
-            == self._splitter.splits.list[self._most_recent_split_index].loops
-        ):
-            if self._last_split_active is not True:
-                self._last_split_active = True
-                flag_changed = True
-        else:
-            if self._last_split_active is not False:
-                self._last_split_active = False
-                flag_changed = True
-
-        return flag_changed
-
-    def _set_buttons_and_hotkeys_enabled(self) -> None:
-        """Set the enabled status of buttons and hotkeys, depending on the
-        flags set in `_update_flags`.
-
-        Since the status of these buttons and hotkeys depends entirely on the
-        flags in `_update_flags`, this method is only called if `_update_flags`
-        returns True.
-        """
-        if self._splits_active:
-            # Enable split
-            self._split_hotkey_enabled = True
-
-            # Enable screenshots if video is on
-            if self._video_active:
-                self._main_window.screenshot_button.setEnabled(True)
-                self._main_window.pause_comparison_button.setEnabled(True)
-            else:
-                self._main_window.screenshot_button.setEnabled(False)
-                self._main_window.pause_comparison_button.setEnabled(False)
-
-            # Enable undo and previous if this isn't the first split
-            if self._first_split_active:
-                self._undo_hotkey_enabled = False
-                self._main_window.undo_split_button.setEnabled(False)
-                self._main_window.previous_split_button.setEnabled(False)
-            else:
-                self._undo_hotkey_enabled = True
-                self._main_window.undo_split_button.setEnabled(True)
-                self._main_window.previous_split_button.setEnabled(True)
-
-            # Enable skip and next if this isn't the last split
-            if self._last_split_active:
-                self._skip_hotkey_enabled = False
-                self._main_window.skip_split_button.setEnabled(False)
-                self._main_window.next_split_button.setEnabled(False)
-            else:
-                self._skip_hotkey_enabled = True
-                self._main_window.skip_split_button.setEnabled(True)
-                self._main_window.next_split_button.setEnabled(True)
-
-        else:
-            # Disable split, undo, skip, previous, next split, pause
-            self._split_hotkey_enabled = False
-            self._undo_hotkey_enabled = False
-            self._skip_hotkey_enabled = False
-            self._main_window.undo_split_button.setEnabled(False)
-            self._main_window.skip_split_button.setEnabled(False)
-            self._main_window.previous_split_button.setEnabled(False)
-            self._main_window.next_split_button.setEnabled(False)
-            self._main_window.pause_comparison_button.setEnabled(False)
-
-            # Enable screenshots if video is on
-            if self._video_active:
-                self._main_window.screenshot_button.setEnabled(True)
-            else:
-                self._main_window.screenshot_button.setEnabled(False)
-
-    def _null_match_percent_string(self) -> None:
-        """Return a string representing a blank match percent with the number
-        of decimal places the user chooses in settings.
-
-        Returns:
-            str: The null match percent string. Possible values are "--",
-                "--.-", and "--.--".
-        """
-        match_percent_string = "--"
-        decimals = settings.get_int("MATCH_PERCENT_DECIMALS")
-        if decimals > 0:
-            match_percent_string += "."
-            while decimals > 0:
-                match_percent_string += "-"
-                decimals -= 1
-        return match_percent_string
-
-    def _formatted_match_percent_string(
-        self, match_percent: float, decimals: int
-    ) -> str:
-        """Format a raw match percent into a string with the number of decimal
-        places the user chooses.
-
-        Args:
-            match_percent (float): The raw integer match. E.g., 0.8931285.
-            decimals (int): The number of trailing decimals.
-
-        Returns:
-            str: The formatted value. E.g., "89.3".
-        """
-        format_string = f"{{:.{decimals}f}}"
-        return format_string.format(match_percent * 100)

--- a/src/ui/ui_controller.py
+++ b/src/ui/ui_controller.py
@@ -424,7 +424,7 @@ class UIController:
             ):
                 time.sleep(0.001)
             self._splitter.splits.next_split_image()
-            self._splitter.changing_splits = False            
+            self._splitter.changing_splits = False
 
     def _request_reset_splits(self) -> None:
         """Tell `splitter.splits` to call `reset_split_images`, and ask
@@ -1980,7 +1980,7 @@ class UIController:
             key_name, key_code = key.char, key.vk
         except AttributeError:
             key_name, key_code = str(key).replace("Key.", ""), key.value.vk
-    
+
         # Use #1 (set hotkey settings in settings window)
         for hotkey_line_edit in [
             self._settings_window.split_hotkey_line_edit,
@@ -2151,7 +2151,10 @@ class UIController:
             # If key didn't get pressed, OR if it did get pressed but global
             # hotkeys are off and the app isn't in focus, move the split image
             # forward, since pressing the key on its own won't do that
-            if len(key_code) == 0 or (self._application.focusWindow() is None and not settings.get_bool("GLOBAL_HOTKEYS_ENABLED")):
+            if len(key_code) == 0 or (
+                self._application.focusWindow() is None
+                and not settings.get_bool("GLOBAL_HOTKEYS_ENABLED")
+            ):
                 self._request_next_split()
 
     def _update_label_and_button_text(self) -> None:

--- a/src/ui/ui_controller.py
+++ b/src/ui/ui_controller.py
@@ -1254,15 +1254,16 @@ class UIController:
         if settings.get_bool("SHOW_MIN_VIEW"):
             return
 
-        video_alive = self._splitter.capture_thread.is_alive()
+        frame = self._splitter.frame_pixmap
         video = self._main_window.video_display
 
         # Video not connected, but video frame on UI
-        if video.text() == "" and not video_alive:
-            video.setText(self._main_window.video_display_txt)
-        # Video is connected, but is not showing on UI
-        elif self._splitter.frame_pixmap is not None:
-            video.setPixmap(self._splitter.frame_pixmap)
+        if frame is None:
+            if video.text() == "":
+                video.setText(self._main_window.video_display_txt)
+        # Video is connected, update it
+        else:
+            video.setPixmap(frame)
 
     def _update_video_title(self) -> None:
         """Adjust video title depending on whether video is alive."""

--- a/src/ui/ui_controller.py
+++ b/src/ui/ui_controller.py
@@ -1338,24 +1338,22 @@ class UIController:
         Keep track of both overlays, regardless of view, so we can hide the one
         not currently in use.
         """
-        if settings.get_bool("SHOW_MIN_VIEW"):
-            overlay = self._main_window.min_view_overlay
-            self._main_window.split_overlay.setVisible(False)
-        else:
-            overlay = self._main_window.split_overlay
-            self._main_window.min_view_overlay.setVisible(False)
+        overlay = self._main_window.split_overlay
         delay_txt = self._main_window.overlay_delay_txt
         pause_txt = self._main_window.overlay_pause_txt
+        min_view = settings.get_bool("SHOW_MIN_VIEW")
 
         # Splitter is delaying pre-split
         if self._splitter.delaying and self._splitter.delay_remaining is not None:
-            overlay.setVisible(True)
-            overlay.setText(delay_txt.format(amount=self._splitter.delay_remaining))
+            if not min_view:
+                overlay.setVisible(True)
+                overlay.setText(delay_txt.format(self._splitter.delay_remaining))
 
         # Splitter is pausing post-split
         elif self._splitter.suspended and self._splitter.suspend_remaining is not None:
-            overlay.setVisible(True)
-            overlay.setText(pause_txt.format(amount=self._splitter.suspend_remaining))
+            if not min_view:
+                overlay.setVisible(True)
+                overlay.setText(pause_txt.format(self._splitter.suspend_remaining))
 
         # Splitter isn't pausing or delaying, but the overlay is showing
         elif overlay.text() != "":

--- a/src/ui/ui_controller.py
+++ b/src/ui/ui_controller.py
@@ -125,7 +125,7 @@ class UIController:
 
         # "Update available" message box
         self._main_window.update_available_msg.buttonClicked.connect(
-            self._update_message_box_action
+            self.update_available_msg_action
         )
 
         # Split directory line edit
@@ -137,14 +137,12 @@ class UIController:
         self._main_window.split_dir_button.clicked.connect(self.set_split_dir_path)
 
         # Minimal view / full view button
-        self._main_window.minimal_view_button.clicked.connect(
+        self._main_window.min_view_button.clicked.connect(
             lambda: settings.set_value(
                 "SHOW_MIN_VIEW", not settings.get_bool("SHOW_MIN_VIEW")
             )
         )
-        self._main_window.minimal_view_button.clicked.connect(
-            self._set_main_window_layout
-        )
+        self._main_window.min_view_button.clicked.connect(self._set_main_window_layout)
 
         # Next source button
         self._main_window.next_source_button.clicked.connect(
@@ -230,6 +228,11 @@ class UIController:
         self._main_window.show()
 
     def _poll(self) -> None:
+        """Use information from UI, splitter, and keyboard to update the UI
+        and splitter.
+
+        Should be called each frame.
+        """
         self._update_from_splitter()
         self._update_from_keyboard()
 
@@ -450,7 +453,7 @@ class UIController:
         )
         self._main_window.split_directory_box.setText(elided_path)
 
-    def _update_message_box_action(self, button: QAbstractButton):
+    def update_available_msg_action(self, button: QAbstractButton):
         """React to button press in _main_window.update_available_msg.
 
         Args:
@@ -693,10 +696,10 @@ class UIController:
         """
         frame = self._splitter.comparison_frame
         if frame is None:
-            message = self._main_window.screenshot_err_no_video
-            message.show()
+            msg = self._main_window.screenshot_err_no_video
+            msg.show()
             # Close message box after 10 seconds
-            QTimer.singleShot(10000, lambda: message.done(0))
+            QTimer.singleShot(10000, lambda: msg.done(0))
             return
 
         image_dir = settings.get_str("LAST_IMAGE_DIR")
@@ -712,23 +715,18 @@ class UIController:
             if settings.get_bool("OPEN_SCREENSHOT_ON_CAPTURE"):
                 self._open_file_or_dir(screenshot_path)
             else:
-                self._main_window.screenshot_ok_msg.setInformativeText(
-                    f"Screenshot saved to:\n{screenshot_path}"
-                )
-                self._main_window.screenshot_ok_msg.setIconPixmap(
-                    QPixmap(screenshot_path).scaledToWidth(150)
-                )
-
-                message = self._main_window.screenshot_ok_msg
-                message.show()
+                msg = self._main_window.screenshot_ok_msg
+                msg.setInformativeText(f"Screenshot saved to:\n{screenshot_path}")
+                msg.setIconPixmap(QPixmap(screenshot_path).scaledToWidth(150))
+                msg.show()
                 # Close message box after 10 seconds
-                QTimer.singleShot(10000, lambda: message.done(0))
+                QTimer.singleShot(10000, lambda: msg.done(0))
 
         else:  # File couldn't be written to the split image directory
-            message = self._main_window.screenshot_error_no_file_message_box
-            message.show()
+            msg = self._main_window.screenshot_error_no_file_message_box
+            msg.show()
             # Close message box after 10 seconds
-            QTimer.singleShot(10000, lambda: message.done(0))
+            QTimer.singleShot(10000, lambda: msg.done(0))
 
     def get_file_number(self, dir: str) -> str:
         """Return the lowest three-digit number that will allow a unique
@@ -769,10 +767,10 @@ class UIController:
             path (str): The file to open.
         """
         if not Path(path).exists():
-            message = self._main_window.err_not_found_msg
-            message.show()
+            msg = self._main_window.err_not_found_msg
+            msg.show()
             # Close message box after 10 seconds
-            QTimer.singleShot(10000, lambda: message.done(0))
+            QTimer.singleShot(10000, lambda: msg.done(0))
             return
 
         if platform.system() == "Windows":
@@ -818,7 +816,7 @@ class UIController:
             QRect(92 + left, 239 + top, 251, 31)
         )
         self._main_window.next_button.setGeometry(QRect(344 + left, 224 + top, 31, 31))
-        self._main_window.minimal_view_button.setGeometry(
+        self._main_window.min_view_button.setGeometry(
             QRect(60 + left, 270 + top, 100, 31)
         )
         self._main_window.video_title.setGeometry(QRect(161 + left, 270 + top, 213, 31))
@@ -902,7 +900,7 @@ class UIController:
         self._main_window.split_dir_button.setGeometry(
             QRect(60 + left, 225 + top, 180, 30)
         )
-        self._main_window.minimal_view_button.setGeometry(
+        self._main_window.min_view_button.setGeometry(
             QRect(60 + left, 270 + top, 100, 31)
         )
         self._main_window.next_source_button.setGeometry(
@@ -982,7 +980,7 @@ class UIController:
         self._main_window.split_dir_button.setGeometry(
             QRect(60 + left, 225 + top, 180, 30)
         )
-        self._main_window.minimal_view_button.setGeometry(
+        self._main_window.min_view_button.setGeometry(
             QRect(60 + left, 270 + top, 100, 31)
         )
         self._main_window.next_source_button.setGeometry(
@@ -1062,7 +1060,7 @@ class UIController:
         self._main_window.split_dir_button.setGeometry(
             QRect(60 + left, 225 + top, 180, 30)
         )
-        self._main_window.minimal_view_button.setGeometry(
+        self._main_window.min_view_button.setGeometry(
             QRect(60 + left, 270 + top, 100, 31)
         )
         self._main_window.next_source_button.setGeometry(
@@ -1142,7 +1140,7 @@ class UIController:
         self._main_window.split_dir_button.setGeometry(
             QRect(60 + left, 225 + top, 180, 30)
         )
-        self._main_window.minimal_view_button.setGeometry(
+        self._main_window.min_view_button.setGeometry(
             QRect(60 + left, 270 + top, 100, 31)
         )
         self._main_window.next_source_button.setGeometry(
@@ -1179,37 +1177,44 @@ class UIController:
         self._main_window.setFixedSize(904, 452 + self._main_window.HEIGHT_CORRECTION)
 
     def _set_button_and_label_text(self, truncate: bool) -> None:
-        """Adjust button and label text according to aspect ratio and minimal
-        view status.
+        """Set button and label text according to aspect ratio and min view.
 
         Args:
             truncate (bool): If True, each widget's short text is used;
                 otherwise, each widget's default (long) text is used.
         """
+        # Min view button
         if settings.get_bool("SHOW_MIN_VIEW"):
-            self._main_window.minimal_view_button.setText("Full view")
+            min_view_txt = self._main_window.min_view_full_txt
         else:
-            self._main_window.minimal_view_button.setText("Minimal view")
+            min_view_txt = self._main_window.min_view_min_txt
 
+        # Other buttons
         if truncate:
-            self._main_window.screenshot_button.setText("Screenshot")
-            self._main_window.match_percent_label.setText("Sim:")
-            self._main_window.highest_percent_label.setText("High:")
-            self._main_window.threshold_percent_label.setText("Thr:")
-            self._main_window.undo_button.setText("Undo")
-            self._main_window.skip_button.setText("Skip")
-            self._main_window.reset_button.setText("Reset")
-
+            screenshot_txt = self._main_window.screenshot_button_short_txt
+            match_txt = self._main_window.match_percent_short_txt
+            highest_txt = self._main_window.highest_percent_short_txt
+            threshold_txt = self._main_window.threshold_percent_short_txt
+            undo_txt = self._main_window.undo_button_short_txt
+            skip_txt = self._main_window.skip_button_short_txt
+            reset_txt = self._main_window.reset_button_short_txt
         else:
-            self._main_window.screenshot_button.setText("Take screenshot")
-            self._main_window.match_percent_label.setText("Similarity to split image:")
-            self._main_window.highest_percent_label.setText(
-                "Highest similarity so far:"
-            )
-            self._main_window.threshold_percent_label.setText("Threshold similarity:")
-            self._main_window.undo_button.setText("Undo split")
-            self._main_window.skip_button.setText("Skip split")
-            self._main_window.reset_button.setText("Reset splits")
+            screenshot_txt = self._main_window.screenshot_button_long_txt
+            match_txt = self._main_window.match_percent_long_txt
+            highest_txt = self._main_window.highest_percent_long_txt
+            threshold_txt = self._main_window.threshold_percent_long_txt
+            undo_txt = self._main_window.undo_button_long_txt
+            skip_txt = self._main_window.skip_button_long_txt
+            reset_txt = self._main_window.reset_button_long_txt
+
+        self._main_window.min_view_button.setText(min_view_txt)
+        self._main_window.screenshot_button.setText(screenshot_txt)
+        self._main_window.match_percent_label.setText(match_txt)
+        self._main_window.highest_percent_label.setText(highest_txt)
+        self._main_window.threshold_percent_label.setText(threshold_txt)
+        self._main_window.undo_button.setText(undo_txt)
+        self._main_window.skip_button.setText(skip_txt)
+        self._main_window.reset_button.setText(reset_txt)
 
     def _set_nonessential_widgets_visible(self, visible: bool) -> None:
         """Set widget visibility according to minimal view status.
@@ -1301,29 +1306,30 @@ class UIController:
                 split_label.setText("")
                 loop_label.setText("")
                 splits_min_label.setText(splits_down_txt)
-                splits_min_label.raise_()
+                splits_min_label.raise_()  # Make sure it's not being covered
 
         # UI showing split but split has been changed, resized, or reset
         elif self._redraw_split_labels:
             self._redraw_split_labels = False
+
             current_split_image = self._splitter.splits.list[current_index]
-
-            if not settings.get_bool("SHOW_MIN_VIEW"):
-                split_display.setPixmap(current_split_image.pixmap)
-
             elided_name = split_label.fontMetrics().elidedText(
                 current_split_image.name, Qt.ElideRight, split_label.width()
             )
-            split_label.setText(elided_name)
-
-            splits_min_label.setText("")
-            splits_min_label.lower()
-
             total_loops = current_split_image.loops
+            loop_txt = self._main_window.split_loop_label_empty_txt
+
+            if not settings.get_bool("SHOW_MIN_VIEW"):
+                split_display.setPixmap(current_split_image.pixmap)
+            split_label.setText(elided_name)
             if total_loops == 0:
-                loop_label.setText("Split does not loop")
+                loop_txt = self._main_window.split_loop_label_empty_txt
+                loop_label.setText(loop_txt)
             else:
-                loop_label.setText(f"Loop {current_loop} of {total_loops}")
+                loop_txt = self._main_window.split_loop_label_txt
+                loop_label.setText(loop_txt.format(current_loop, total_loops))
+            splits_min_label.setText("")
+            splits_min_label.lower()  # Make sure it's not covering others
 
     def _update_split_delay_suspend(self) -> None:
         """Display remaining delay or suspend time.

--- a/src/ui/ui_controller.py
+++ b/src/ui/ui_controller.py
@@ -350,7 +350,7 @@ class UIController:
 
     def _request_previous_split(self) -> None:
         """Tell `splitter.splits` to call `previous_split_image`, and ask
-        splitter._look_for_match to reset its flags.
+        splitter._look_for_match to reset its flags if needed.
 
         If self._splitter.current_match_percent is None, this means that
         splitter.look_for_match isn't active, and we can move to the next split
@@ -382,7 +382,7 @@ class UIController:
 
     def _request_next_split(self) -> None:
         """Tell `splitter.splits` to call `next_split_image`, and ask
-        splitter._look_for_match to reset its flags.
+        splitter._look_for_match to reset its flags if needed.
 
         If self._splitter.current_match_percent is None, this means that
         splitter.look_for_match isn't active, and we can move to the next split
@@ -414,7 +414,7 @@ class UIController:
 
     def _request_reset_splits(self) -> None:
         """Tell `splitter.splits` to call `reset_split_images`, and ask
-        splitter._look_for_match to reset its flags.
+        splitter._look_for_match to reset its flags if necessary.
 
         Kills `splitter.compare_thread` (this allows the splitter to exit
         gracefully if the split image directory has changed to an empty
@@ -2120,12 +2120,12 @@ class UIController:
             key_code = settings.get_str("PAUSE_HOTKEY_CODE")
             if len(key_code) > 0:
                 self._press_hotkey(key_code)
-            self._splitter.splits.next_split_image()
+            self._request_next_split()
 
         # Dummy split (silently advance to next split)
         elif self._splitter.dummy_split_action:
             self._splitter.dummy_split_action = False
-            self._splitter.splits.next_split_image()
+            self._request_next_split()
 
         # Normal split (press split hotkey)
         elif self._splitter.normal_split_action:
@@ -2137,7 +2137,7 @@ class UIController:
             # hotkeys are off and the app isn't in focus, move the split image
             # forward, since pressing the key on its own won't do that
             if len(key_code) == 0 or (self._application.focusWindow() is None and not settings.get_bool("GLOBAL_HOTKEYS_ENABLED")):
-                self._splitter.splits.next_split_image()
+                self._request_next_split()
 
     def _update_label_and_button_text(self) -> None:
         """Update label and button text in the UI based on splitter state."""

--- a/src/ui/ui_controller.py
+++ b/src/ui/ui_controller.py
@@ -219,7 +219,7 @@ class UIController:
         )
         self._keyboard_listener.start()
 
-        # Start timer
+        # Start poller
         self._poller = QTimer()
         self._poller.setInterval(1000 // settings.get_int("FPS"))
         self._poller.timeout.connect(self._poll)
@@ -1322,7 +1322,7 @@ class UIController:
             if not settings.get_bool("SHOW_MIN_VIEW"):
                 split_display.setPixmap(current_split_image.pixmap)
             split_label.setText(elided_name)
-            if total_loops == 0:
+            if total_loops == 1:
                 loop_txt = self._main_window.split_loop_label_empty_txt
                 loop_label.setText(loop_txt)
             else:
@@ -1458,7 +1458,7 @@ class UIController:
                 self._main_window.pause_button.setEnabled(False)
 
             # Enable undo and previous if this isn't the first split
-            if current_split_index == 0 and loop == 0:
+            if current_split_index == 0 and loop == 1:
                 self._undo_hotkey_enabled = False
                 self._main_window.undo_button.setEnabled(False)
                 self._main_window.previous_button.setEnabled(False)

--- a/src/ui/ui_controller.py
+++ b/src/ui/ui_controller.py
@@ -2133,7 +2133,10 @@ class UIController:
             key_code = settings.get_str("SPLIT_HOTKEY_CODE")
             if len(key_code) > 0:
                 self._press_hotkey(key_code)
-            else:
+            # If key didn't get pressed, OR if it did get pressed but global
+            # hotkeys are off and the app isn't in focus, move the split image
+            # forward, since pressing the key on its own won't do that
+            if len(key_code) == 0 or (self._application.focusWindow() is None and not settings.get_bool("GLOBAL_HOTKEYS_ENABLED")):
                 self._splitter.splits.next_split_image()
 
     def _update_label_and_button_text(self) -> None:

--- a/src/ui/ui_controller.py
+++ b/src/ui/ui_controller.py
@@ -221,7 +221,7 @@ class UIController:
 
         # Start poller
         self._poller = QTimer()
-        self._poller.setInterval(1000 // settings.get_int("FPS"))
+        self._poller.setInterval(self._get_interval())
         self._poller.timeout.connect(self._poll)
         self._poller.start()
 
@@ -592,7 +592,7 @@ class UIController:
 
             # Send new FPS value to controller and splitter
             if spinbox == self._settings_window.fps_spinbox:
-                self._poller.setInterval(1000 // value)
+                self._poller.setInterval(self._get_interval())
                 self._splitter.target_fps = value
 
             settings.set_value(setting_string, value)
@@ -1492,6 +1492,19 @@ class UIController:
                 match_percent_string += "-"
                 decimals -= 1
         return match_percent_string
+
+    def _get_interval(self) -> int:
+        """Calculate the rate at which _poller should poll.
+
+        The minimum is 20 Hz (represented by the 50 ms value below). Any
+        slower than 20 Hz and the UI starts to look pretty bad.
+
+        1000 is used because that is the number of ms in a second.
+
+        Returns:
+            int: The amount of time in ms the poller waits between calls.
+        """
+        return min(1000 // settings.get_int("FPS"), 50)
 
     ###########################
     #                         #

--- a/src/ui/ui_main_window.py
+++ b/src/ui/ui_main_window.py
@@ -286,12 +286,6 @@ class UIMainWindow(QMainWindow):
         self.split_overlay.setObjectName("split_overlay")
         self.split_overlay.setVisible(False)
 
-        self.min_view_overlay = QLabel(self._container)
-        self.min_view_overlay.setAlignment(Qt.AlignCenter)
-        self.min_view_overlay.setVisible(False)
-        # This label's always in the same spot
-        self.min_view_overlay.setGeometry(QRect(161 + left, 270 + top, 213, 31))
-
         self.overlay_delay_txt = "Splitting in {amount:.1f} s"
         self.overlay_pause_txt = "Paused for {amount:.1f} s"
 

--- a/src/ui/ui_main_window.py
+++ b/src/ui/ui_main_window.py
@@ -408,7 +408,7 @@ class UIMainWindow(QMainWindow):
         self.screenshot_button.setEnabled(False)
         self.screenshot_button.setFocusPolicy(Qt.NoFocus)
         self.screenshot_button_short_txt = "Screenshot"
-        self.screenshot_button_long_txt = "Take Screenshot"
+        self.screenshot_button_long_txt = "Take screenshot"
 
         # Screenshot success message box
         self.screenshot_ok_msg = QMessageBox(self)

--- a/src/ui/ui_main_window.py
+++ b/src/ui/ui_main_window.py
@@ -90,7 +90,7 @@ class UIMainWindow(QMainWindow):
             highest image match percent.
         highest_percent_sign (QLabel): Displays a percent sign after the
             highest image match percent.
-        minimal_view_button (QPushButton): Allows the user to show or hide
+        min_view_button (QPushButton): Allows the user to show or hide
             minimal view.
         split_info_min_label (QLabel): In minimal view, displays text
             saying no splits are active.
@@ -263,6 +263,7 @@ class UIMainWindow(QMainWindow):
         #########################
 
         left, top = self.LEFT_EDGE_CORRECTION, self.TOP_EDGE_CORRECTION
+        self.split_labels_empty_txt = ""
 
         self.split_name_label = QLabel(self._container)
         self.split_name_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
@@ -271,6 +272,9 @@ class UIMainWindow(QMainWindow):
         self.split_loop_label = QLabel(self._container)
         self.split_loop_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
         self.split_loop_label.setAlignment(Qt.AlignCenter)
+        self.split_loop_label_empty_txt = "Split does not loop"
+        # Include placeholders for current and total loops
+        self.split_loop_label_txt = "Loop {} of {}"
 
         self.split_display = QLabel(self._container)
         self.split_display.setAlignment(Qt.AlignCenter)
@@ -310,6 +314,8 @@ class UIMainWindow(QMainWindow):
         self.match_percent_label.setAlignment(
             Qt.AlignRight | Qt.AlignTrailing | Qt.AlignVCenter
         )
+        self.match_percent_short_txt = "Sim:"
+        self.match_percent_long_txt = "Similarity to split image:"
 
         self.match_percent = QLabel(self._container)
         self.match_percent.setTextInteractionFlags(Qt.TextSelectableByMouse)
@@ -328,6 +334,8 @@ class UIMainWindow(QMainWindow):
         self.highest_percent_label.setAlignment(
             Qt.AlignRight | Qt.AlignTrailing | Qt.AlignVCenter
         )
+        self.highest_percent_short_txt = "High:"
+        self.highest_percent_long_txt = "Highest similarity so far:"
 
         self.highest_percent = QLabel(self._container)
         self.highest_percent.setTextInteractionFlags(Qt.TextSelectableByMouse)
@@ -346,6 +354,8 @@ class UIMainWindow(QMainWindow):
         self.threshold_percent_label.setAlignment(
             Qt.AlignRight | Qt.AlignTrailing | Qt.AlignVCenter
         )
+        self.threshold_percent_short_txt = "Thr:"
+        self.threshold_percent_long_txt = "Threshold similarity:"
 
         self.threshold_percent = QLabel(self._container)
         self.threshold_percent.setTextInteractionFlags(Qt.TextSelectableByMouse)
@@ -384,8 +394,10 @@ class UIMainWindow(QMainWindow):
         ###############################
 
         # Minimal view button
-        self.minimal_view_button = QPushButton(self._container)
-        self.minimal_view_button.setFocusPolicy(Qt.NoFocus)
+        self.min_view_button = QPushButton(self._container)
+        self.min_view_button.setFocusPolicy(Qt.NoFocus)
+        self.min_view_min_txt = "Minimal view"
+        self.min_view_full_txt = "Full view"
 
         # Next source button
         self.next_source_button = QPushButton("Next source", self._container)
@@ -395,6 +407,8 @@ class UIMainWindow(QMainWindow):
         self.screenshot_button = QPushButton(self._container)
         self.screenshot_button.setEnabled(False)
         self.screenshot_button.setFocusPolicy(Qt.NoFocus)
+        self.screenshot_button_short_txt = "Screenshot"
+        self.screenshot_button_long_txt = "Take Screenshot"
 
         # Screenshot success message box
         self.screenshot_ok_msg = QMessageBox(self)
@@ -436,21 +450,24 @@ class UIMainWindow(QMainWindow):
         self.next_button.setEnabled(False)
         self.next_button.setFocusPolicy(Qt.NoFocus)
 
-        # Skip split button
-        self.skip_button = QPushButton(self._container)
-        self.skip_button.setEnabled(False)
-        self.skip_button.setFocusPolicy(Qt.NoFocus)
-
         # Undo split button
         self.undo_button = QPushButton(self._container)
         self.undo_button.setEnabled(False)
         self.undo_button.setFocusPolicy(Qt.NoFocus)
+        self.undo_button_short_txt = "Undo"
+        self.undo_button_long_txt = "Undo split"
+
+        # Skip split button
+        self.skip_button = QPushButton(self._container)
+        self.skip_button.setEnabled(False)
+        self.skip_button.setFocusPolicy(Qt.NoFocus)
+        self.skip_button_short_txt = "Skip"
+        self.skip_button_long_txt = "Skip split"
 
         # Pause comparison / unpause comparison button
         self.pause_button = QPushButton(self._container)
         self.pause_button.setEnabled(False)
         self.pause_button.setFocusPolicy(Qt.NoFocus)
-
         self.pause_short_txt = "Pause comp"
         self.pause_long_txt = "Pause comparison"
         self.unpause_short_txt = "Unpause comp"
@@ -459,6 +476,8 @@ class UIMainWindow(QMainWindow):
         # Reset splits button
         self.reset_button = QPushButton(self._container)
         self.reset_button.setFocusPolicy(Qt.NoFocus)
+        self.reset_button_short_txt = "Reset"
+        self.reset_button_long_txt = "Reset splits"
 
         ##################################
         #                                #

--- a/src/ui/ui_main_window.py
+++ b/src/ui/ui_main_window.py
@@ -286,8 +286,8 @@ class UIMainWindow(QMainWindow):
         self.split_overlay.setObjectName("split_overlay")
         self.split_overlay.setVisible(False)
 
-        self.overlay_delay_txt = "Splitting in {amount:.1f} s"
-        self.overlay_pause_txt = "Paused for {amount:.1f} s"
+        self.overlay_delay_txt = "Splitting in {:.1f} s"
+        self.overlay_pause_txt = "Paused for {:.1f} s"
 
         self.split_info_min_label = QLabel(self._container)
         self.split_info_min_label.setTextInteractionFlags(Qt.TextSelectableByMouse)

--- a/src/ui/ui_main_window.py
+++ b/src/ui/ui_main_window.py
@@ -262,6 +262,8 @@ class UIMainWindow(QMainWindow):
         #                       #
         #########################
 
+        left, top = self.LEFT_EDGE_CORRECTION, self.TOP_EDGE_CORRECTION
+
         self.split_name_label = QLabel(self._container)
         self.split_name_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
         self.split_name_label.setAlignment(Qt.AlignCenter)
@@ -279,13 +281,20 @@ class UIMainWindow(QMainWindow):
         self.split_overlay.setAlignment(Qt.AlignCenter)
         self.split_overlay.setObjectName("split_overlay")
         self.split_overlay.setVisible(False)
+
+        self.min_view_overlay = QLabel(self._container)
+        self.min_view_overlay.setAlignment(Qt.AlignCenter)
+        self.min_view_overlay.setVisible(False)
+        # This label's always in the same spot
+        self.min_view_overlay.setGeometry(QRect(161 + left, 270 + top, 213, 31))
+
         self.overlay_delay_txt = "Splitting in {amount:.1f} s"
         self.overlay_pause_txt = "Paused for {amount:.1f} s"
 
         self.split_info_min_label = QLabel(self._container)
         self.split_info_min_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
         self.split_info_min_label.setAlignment(Qt.AlignCenter)
-        left, top = self.LEFT_EDGE_CORRECTION, self.TOP_EDGE_CORRECTION
+        # This label's always in the same spot
         self.split_info_min_label.setGeometry(QRect(92 + left, 225 + top, 251, 31))
         self.min_video_down_txt = "Video status:   down"
         self.min_video_live_txt = "Video status:   healthy"

--- a/src/ui/ui_main_window.py
+++ b/src/ui/ui_main_window.py
@@ -72,108 +72,108 @@ class UIMainWindow(QMainWindow):
             pushed down.
         close_window_shortcut (QShortcut): Keyboard shortcut to close the main
             window.
-        current_match_percent (QLabel): Displays the current image match
+        match_percent (QLabel): Displays the current image match
             percent, or a null string (see ui_controller._update_ui for
             details).
-        current_match_percent_label (QLabel): Displays text describing the
+        match_percent_label (QLabel): Displays text describing the
             current image match percent.
-        current_match_percent_sign (QLabel): Displays a percent sign after the
+        match_percent_sign (QLabel): Displays a percent sign after the
             current image match percent.
-        file_not_found_message_box (QMessageBox): Message to display if the
+        err_not_found_msg (QMessageBox): Message to display if the
             controller attempts to open a file or directory that doesn't exist.
         help_action (QAction): Adds a menu bar item which triggers opening the
             user manual.
-        highest_match_percent (QLabel): Displays the highest image match
+        highest_percent (QLabel): Displays the highest image match
             percent so far, or a null string (see ui_controller._update_ui for
             details).
-        highest_match_percent_label (QLabel): Displays text describing the
+        highest_percent_label (QLabel): Displays text describing the
             highest image match percent.
-        highest_match_percent_sign (QLabel): Displays a percent sign after the
+        highest_percent_sign (QLabel): Displays a percent sign after the
             highest image match percent.
         minimal_view_button (QPushButton): Allows the user to show or hide
             minimal view.
-        minimal_view_no_splits_label (QLabel): In minimal view, displays text
+        split_info_min_label (QLabel): In minimal view, displays text
             saying no splits are active.
         next_source_button (QPushButton): Allows the user to attempt to connect
             to the next video source, if one exists.
-        next_split_button (QPushButton): Allows the user to move to the next
+        next_button (QPushButton): Allows the user to move to the next
             split without triggering any hotkeys.
-        pause_comparison_button (QPushButton): Allows the user to stop the
+        pause_button (QPushButton): Allows the user to stop the
             splitter from comparing images to the split image.
-        pause_comparison_button_pause_text_default (str): Text prompting the
+        pause_button_overlay_pause_txt_default (str): Text prompting the
             user to pause the splitter (default length).
-        pause_comparison_button_pause_text_truncated (str): Text prompting the
+        pause_button_overlay_pause_txt_truncated (str): Text prompting the
             user to pause the splitter (short length).
-        pause_comparison_button_unpause_text_default (str): Text prompting the
+        pause_button_unoverlay_pause_txt_default (str): Text prompting the
             user to unpause the splitter (default length).
-        pause_comparison_button_unpause_text_truncated (str): Text prompting
+        pause_button_unoverlay_pause_txt_truncated (str): Text prompting
             the user to unpause the splitter (short length).
-        previous_split_button (QPushButton): Allows the user to move to the
+        previous_button (QPushButton): Allows the user to move to the
             previous split without triggering any hotkeys.
-        reload_video_button (QPushButton): Allows the user to attempt to
+        reconnect_button (QPushButton): Allows the user to attempt to
             reconnect to the current video source.
-        reset_splits_button (QPushButton): Allows the user to reset a run. This
+        reset_button (QPushButton): Allows the user to reset a run. This
             also refreshes the split image list if more splits have been added
             to the folder or if names have been updated.
         screenshot_button (QPushButton): Allows the user to take a screenshot
             of the current video frame and save it to the current split
             directory.
-        screenshot_error_no_video_message_box (QMessageBox): Message to display
+        screenshot_err_no_video (QMessageBox): Message to display
             if the screenshot button or hotkey was pressed, ui_controller.
             take_screenshot was called, but splitter.comparison_frame was None.
-        screenshot_error_no_file_message_box (QMessageBox): Message to display
+        screenshot_err_no_file (QMessageBox): Message to display
             if the screenshot was captured but could not be written to a file
             (99% this should come down to permissions errors).
-        screenshot_success_message_box (QMessageBox): Message to display if a
+        screenshot_ok_msg (QMessageBox): Message to display if a
             screenshot was taken successfully and the user doesn't have "open
             screenshots on capture" enabled.
         settings_action (QAction): Adds a menu bar item which triggers opening
             the settings menu.
-        skip_split_button (QPushButton): Allows the user to move to the next
+        skip_button (QPushButton): Allows the user to move to the next
             split. Does the same thing as pressing the skip split hotkey.
-        split_directory_button (QPushButton): Allows the user to select a split
+        split_dir_button (QPushButton): Allows the user to select a split
             image folder.
-        split_directory_line_edit (QLineEdit): Shows the path to the current
+        split_directory_box (QLineEdit): Shows the path to the current
             split image folder. If clicked, it opens the split image folder in
             the OS's file explorer.
-        split_image_default_text (str): Informs the user there are no split
+        split_display_txt (str): Informs the user there are no split
             images loaded currently.
-        split_image_display (QLabel): Display split images if loaded, or else
-            show the split_image_default_text.
-        split_image_loop_label (QLabel): Informs the user about the current
+        split_display (QLabel): Display split images if loaded, or else
+            show the split_display_txt.
+        split_loop_label (QLabel): Informs the user about the current
             split's loop information.
-        split_image_overlay (QLabel): Informs the user that a pre-split delay
+        split_overlay (QLabel): Informs the user that a pre-split delay
             or post-split pause is taking place.
         split_name_label (QLabel): Shows the current split name.
-        threshold_match_percent (QLabel): Displays the threshold image match
+        threshold_percent (QLabel): Displays the threshold image match
             percent for the current split, or a null string (see
             ui_controller._update_ui for details).
-        threshold_match_percent_label (QLabel): Displays text describing the
+        threshold_percent_label (QLabel): Displays text describing the
             threshold image match percent.
-        threshold_match_percent_sign (QLabel): Displays a percent sign after
+        threshold_percent_sign (QLabel): Displays a percent sign after
             the threshold image match percent.
-        undo_split_button (QPushButton): Allows the user to move to the
+        undo_button (QPushButton): Allows the user to move to the
             previous split. Does the same thing as pressing the undo split
             hotkey.
-        update_available_later_button_text (str): The text that appears on the
-            "remind me later" button in update_available_message_box.
-        update_available_message_box (QMessageBox): Message that appears when
+        later_button_txt (str): The text that appears on the
+            "remind me later" button in update_available_msg.
+        update_available_msg (QMessageBox): Message that appears when
             an update is available.
-        update_available_open_button_text (str): The text that appears on the
-            "open" button in update_available_message_box.
-        update_available_never_button_text (str): The text that appears on the
-            "don't ask again" button in update_available_message_box.
-        video_feed_display (QLabel): Display video feed if connected, or else
-            show the video_feed_display_default_text.
-        video_feed_display_default_text (str): Informs the user there is no
+        open_button_txt (str): The text that appears on the
+            "open" button in update_available_msg.
+        never_button_txt (str): The text that appears on the
+            "don't ask again" button in update_available_msg.
+        video_display (QLabel): Display video feed if connected, or else
+            show the video_display_txt.
+        video_display_txt (str): Informs the user there is no
             video connected currently.
-        video_feed_label (QLabel): Show information about the current video if
+        video_title (QLabel): Show information about the current video if
             loaded.
-        video_feed_label_down_text_min (str): In minimal view, inform the user
+        video_down_txt_min (str): In minimal view, inform the user
             there is no video connected.
-        video_feed_label_live_text (str): In full view, inform the user the
+        video_live_txt (str): In full view, inform the user the
             video is connected.
-        video_feed_label_live_text_min (str): In minimal view, inform the user
+        video_live_txt_min (str): In minimal view, inform the user
             the video is connected.
     """
 
@@ -201,11 +201,9 @@ class UIMainWindow(QMainWindow):
         self._menu_bar = QMenuBar(self._container)
         self.setMenuBar(self._menu_bar)
 
-        self._menu_bar_pilgrim_autosplitter = self._menu_bar.addMenu(
-            "&Autosplitter Settings"
-        )
-        self._menu_bar_pilgrim_autosplitter.addAction(self.settings_action)
-        self._menu_bar_pilgrim_autosplitter.addAction(self.help_action)
+        self._menu_bar_dropdown = self._menu_bar.addMenu("&Autosplitter Settings")
+        self._menu_bar_dropdown.addAction(self.settings_action)
+        self._menu_bar_dropdown.addAction(self.help_action)
 
         # Layout attributes
         self.LEFT_EDGE_CORRECTION = -44
@@ -219,143 +217,162 @@ class UIMainWindow(QMainWindow):
         self.close_window_shortcut = QShortcut("ctrl+w", self)
         self.close_window_shortcut.activated.connect(self.close)
 
-        ###########
-        #         #
-        # Widgets #
-        #         #
-        ###########
+        #######################
+        #                     #
+        # Widgets (Split dir) #
+        #                     #
+        #######################
 
-        # Split directory button and display
-        self.split_directory_button = QPushButton(
-            "Select split image folder:", self._container
-        )
-        self.split_directory_button.setFocusPolicy(Qt.NoFocus)
+        txt = "Select split image folder:"
+        self.split_dir_button = QPushButton(txt, self._container)
+        self.split_dir_button.setFocusPolicy(Qt.NoFocus)
 
-        self.split_directory_line_edit = ClickableLineEdit(self._container)
-        self.split_directory_line_edit.setAlignment(Qt.AlignLeft)
-        self.split_directory_line_edit.setText(settings.get_str("LAST_IMAGE_DIR"))
+        self.split_directory_box = ClickableLineEdit(self._container)
+        self.split_directory_box.setAlignment(Qt.AlignLeft)
+        self.split_directory_box.setText(settings.get_str("LAST_IMAGE_DIR"))
         # Make sure cursor doesn't change on hover
-        self.split_directory_line_edit.setFocusPolicy(Qt.NoFocus)
+        self.split_directory_box.setFocusPolicy(Qt.NoFocus)
         # Needed to make sure text can't be selected, including blank spaces
         # before and after text. I'm not sure why this is necessary since mouse
         # events are intercepted in ClickableLineEdit anyway, but in my testing
         # this is the case.
-        self.split_directory_line_edit.setReadOnly(True)
+        self.split_directory_box.setReadOnly(True)
+
+        ###########################
+        #                         #
+        # Widgets (Video display) #
+        #                         #
+        ###########################
 
         # Video feed
-        self.video_feed_label = QLabel(self._container)
-        self.video_feed_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
-        self.video_feed_label.setAlignment(Qt.AlignCenter)
+        self.video_title = QLabel(self._container)
+        self.video_title.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        self.video_title.setAlignment(Qt.AlignCenter)
+        self.video_live_txt = "Video feed"
+        self.video_down_txt = ""
 
-        self.video_feed_label_live_text = "Video feed"
-        self.video_feed_label_down_text_min = "Video status:   down"
-        self.video_feed_label_live_text_min = "Video status:   healthy"
+        self.video_display = QLabel(self._container)
+        self.video_display.setAlignment(Qt.AlignCenter)
+        self.video_display.setObjectName("image_label_inactive")
+        self.video_display_txt = "No video feed detected"
 
-        self.video_feed_display = QLabel(self._container)
-        self.video_feed_display.setAlignment(Qt.AlignCenter)
-        self.video_feed_display.setObjectName("image_label_inactive")
-
-        self.video_feed_display_default_text = "No video feed detected"
-
-        # Split image
-        self.minimal_view_no_splits_label = QLabel(self._container)
-        self.minimal_view_no_splits_label.setTextInteractionFlags(
-            Qt.TextSelectableByMouse
-        )
-        self.minimal_view_no_splits_label.setAlignment(Qt.AlignCenter)
-        # This widget is, uniquely, always in the same spot
-        self.minimal_view_no_splits_label.setGeometry(
-            QRect(
-                92 + self.LEFT_EDGE_CORRECTION, 225 + self.TOP_EDGE_CORRECTION, 251, 31
-            )
-        )
+        #########################
+        #                       #
+        # Widgets (Split image) #
+        #                       #
+        #########################
 
         self.split_name_label = QLabel(self._container)
         self.split_name_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
         self.split_name_label.setAlignment(Qt.AlignCenter)
 
-        self.split_image_loop_label = QLabel(self._container)
-        self.split_image_loop_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
-        self.split_image_loop_label.setAlignment(Qt.AlignCenter)
+        self.split_loop_label = QLabel(self._container)
+        self.split_loop_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        self.split_loop_label.setAlignment(Qt.AlignCenter)
 
-        self.split_image_display = QLabel(self._container)
-        self.split_image_display.setAlignment(Qt.AlignCenter)
-        self.split_image_display.setObjectName("image_label_inactive")
-        self.split_image_default_text = "No split images loaded"
+        self.split_display = QLabel(self._container)
+        self.split_display.setAlignment(Qt.AlignCenter)
+        self.split_display.setObjectName("image_label_inactive")
+        self.split_display_txt = "No split images loaded"
 
-        self.split_image_overlay = QLabel(self._container)
-        self.split_image_overlay.setAlignment(Qt.AlignCenter)
-        self.split_image_overlay.setObjectName("split_image_overlay")
-        self.split_image_overlay.setVisible(False)
+        self.split_overlay = QLabel(self._container)
+        self.split_overlay.setAlignment(Qt.AlignCenter)
+        self.split_overlay.setObjectName("split_overlay")
+        self.split_overlay.setVisible(False)
+        self.overlay_delay_txt = "Splitting in {amount:.1f} s"
+        self.overlay_pause_txt = "Paused for {amount:.1f} s"
 
-        # Match percent (current)
-        self.current_match_percent_label = QLabel(self._container)
-        self.current_match_percent_label.setTextInteractionFlags(
-            Qt.TextSelectableByMouse
-        )
-        self.current_match_percent_label.setAlignment(
+        self.split_info_min_label = QLabel(self._container)
+        self.split_info_min_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        self.split_info_min_label.setAlignment(Qt.AlignCenter)
+        left, top = self.LEFT_EDGE_CORRECTION, self.TOP_EDGE_CORRECTION
+        self.split_info_min_label.setGeometry(QRect(92 + left, 225 + top, 251, 31))
+        self.min_video_down_txt = "Video status:   down"
+        self.min_video_live_txt = "Video status:   healthy"
+
+        #############################
+        #                           #
+        # Widgets (Current match %) #
+        #                           #
+        #############################
+
+        self.match_percent_label = QLabel(self._container)
+        self.match_percent_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        self.match_percent_label.setAlignment(
             Qt.AlignRight | Qt.AlignTrailing | Qt.AlignVCenter
         )
 
-        self.current_match_percent = QLabel(self._container)
-        self.current_match_percent.setTextInteractionFlags(Qt.TextSelectableByMouse)
-        self.current_match_percent.setAlignment(
+        self.match_percent = QLabel(self._container)
+        self.match_percent.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        self.match_percent.setAlignment(
             Qt.AlignRight | Qt.AlignTrailing | Qt.AlignVCenter
         )
 
-        self.current_match_percent_sign = QLabel("%", self._container)
-        self.current_match_percent_sign.setTextInteractionFlags(
-            Qt.TextSelectableByMouse
+        #############################
+        #                           #
+        # Widgets (Highest match %) #
+        #                           #
+        #############################
+
+        self.highest_percent_label = QLabel(self._container)
+        self.highest_percent_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        self.highest_percent_label.setAlignment(
+            Qt.AlignRight | Qt.AlignTrailing | Qt.AlignVCenter
         )
-        self.current_match_percent_sign.setAlignment(
+
+        self.highest_percent = QLabel(self._container)
+        self.highest_percent.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        self.highest_percent.setAlignment(
+            Qt.AlignRight | Qt.AlignTrailing | Qt.AlignVCenter
+        )
+
+        ###############################
+        #                             #
+        # Widgets (Threshold match %) #
+        #                             #
+        ###############################
+
+        self.threshold_percent_label = QLabel(self._container)
+        self.threshold_percent_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        self.threshold_percent_label.setAlignment(
+            Qt.AlignRight | Qt.AlignTrailing | Qt.AlignVCenter
+        )
+
+        self.threshold_percent = QLabel(self._container)
+        self.threshold_percent.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        self.threshold_percent.setAlignment(
+            Qt.AlignRight | Qt.AlignTrailing | Qt.AlignVCenter
+        )
+
+        ###########################
+        #                         #
+        # Widgets (Percent signs) #
+        #                         #
+        ###########################
+
+        self.percent_sign_1 = QLabel("%", self._container)
+        self.percent_sign_1.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        self.percent_sign_1.setAlignment(
             Qt.AlignLeading | Qt.AlignLeft | Qt.AlignVCenter
         )
 
-        # Match percent (highest)
-        self.highest_match_percent_label = QLabel(self._container)
-        self.highest_match_percent_label.setTextInteractionFlags(
-            Qt.TextSelectableByMouse
-        )
-        self.highest_match_percent_label.setAlignment(
-            Qt.AlignRight | Qt.AlignTrailing | Qt.AlignVCenter
-        )
-
-        self.highest_match_percent = QLabel(self._container)
-        self.highest_match_percent.setTextInteractionFlags(Qt.TextSelectableByMouse)
-        self.highest_match_percent.setAlignment(
-            Qt.AlignRight | Qt.AlignTrailing | Qt.AlignVCenter
-        )
-
-        self.highest_match_percent_sign = QLabel("%", self._container)
-        self.highest_match_percent_sign.setTextInteractionFlags(
-            Qt.TextSelectableByMouse
-        )
-        self.highest_match_percent_sign.setAlignment(
+        self.percent_sign_2 = QLabel("%", self._container)
+        self.percent_sign_2.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        self.percent_sign_2.setAlignment(
             Qt.AlignLeading | Qt.AlignLeft | Qt.AlignVCenter
         )
 
-        # Match percent (threshold)
-        self.threshold_match_percent_label = QLabel(self._container)
-        self.threshold_match_percent_label.setTextInteractionFlags(
-            Qt.TextSelectableByMouse
-        )
-        self.threshold_match_percent_label.setAlignment(
-            Qt.AlignRight | Qt.AlignTrailing | Qt.AlignVCenter
-        )
-
-        self.threshold_match_percent = QLabel(self._container)
-        self.threshold_match_percent.setTextInteractionFlags(Qt.TextSelectableByMouse)
-        self.threshold_match_percent.setAlignment(
-            Qt.AlignRight | Qt.AlignTrailing | Qt.AlignVCenter
-        )
-
-        self.threshold_match_percent_sign = QLabel("%", self._container)
-        self.threshold_match_percent_sign.setTextInteractionFlags(
-            Qt.TextSelectableByMouse
-        )
-        self.threshold_match_percent_sign.setAlignment(
+        self.percent_sign_3 = QLabel("%", self._container)
+        self.percent_sign_3.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        self.percent_sign_3.setAlignment(
             Qt.AlignLeading | Qt.AlignLeft | Qt.AlignVCenter
         )
+
+        ###############################
+        #                             #
+        # Widgets (Left side buttons) #
+        #                             #
+        ###############################
 
         # Minimal view button
         self.minimal_view_button = QPushButton(self._container)
@@ -371,46 +388,88 @@ class UIMainWindow(QMainWindow):
         self.screenshot_button.setFocusPolicy(Qt.NoFocus)
 
         # Screenshot success message box
-        self.screenshot_success_message_box = QMessageBox(self)
-        self.screenshot_success_message_box.setText("Screenshot taken")
+        self.screenshot_ok_msg = QMessageBox(self)
+        self.screenshot_ok_msg.setText("Screenshot taken")
 
         # Screenshot error message box (no video)
-        self.screenshot_error_no_video_message_box = QMessageBox(self)
-        self.screenshot_error_no_video_message_box.setText("Could not take screenshot")
-        self.screenshot_error_no_video_message_box.setInformativeText(
+        self.screenshot_err_no_video = QMessageBox(self)
+        self.screenshot_err_no_video.setText("Could not take screenshot")
+        self.screenshot_err_no_video.setInformativeText(
             "No video feed detected. Please make sure video feed is active and try again."
         )
-        self.screenshot_error_no_video_message_box.setIcon(QMessageBox.Warning)
+        self.screenshot_err_no_video.setIcon(QMessageBox.Warning)
 
         # Screenshot error message box (file couldn't be saved)
-        self.screenshot_error_no_file_message_box = QMessageBox(self)
-        self.screenshot_error_no_file_message_box.setText("Could not save screenshot")
-        self.screenshot_error_no_file_message_box.setInformativeText(
+        self.screenshot_err_no_file = QMessageBox(self)
+        self.screenshot_err_no_file.setText("Could not save screenshot")
+        self.screenshot_err_no_file.setInformativeText(
             "Pilgrim Autosplitter can't write files to this folder. Please select a different folder and try again."
         )
-        self.screenshot_error_no_file_message_box.setIcon(QMessageBox.Warning)
+        self.screenshot_err_no_file.setIcon(QMessageBox.Warning)
 
-        # Couldn't find file or directory error message box
-        self.file_not_found_message_box = QMessageBox(self)
-        self.file_not_found_message_box.setText("File or folder not found")
-        self.file_not_found_message_box.setInformativeText(
-            "The file or folder could not be found. Please try again."
-        )
-        self.file_not_found_message_box.setIcon(QMessageBox.Warning)
+        ################################
+        #                              #
+        # Widgets (Right side buttons) #
+        #                              #
+        ################################
+
+        # Reload video button
+        self.reconnect_button = QPushButton("Reconnect video", self._container)
+        self.reconnect_button.setFocusPolicy(Qt.NoFocus)
+
+        # Previous split button
+        self.previous_button = QPushButton("<", self._container)
+        self.previous_button.setEnabled(False)
+        self.previous_button.setFocusPolicy(Qt.NoFocus)
+
+        # Next split button
+        self.next_button = QPushButton(">", self._container)
+        self.next_button.setEnabled(False)
+        self.next_button.setFocusPolicy(Qt.NoFocus)
+
+        # Skip split button
+        self.skip_button = QPushButton(self._container)
+        self.skip_button.setEnabled(False)
+        self.skip_button.setFocusPolicy(Qt.NoFocus)
+
+        # Undo split button
+        self.undo_button = QPushButton(self._container)
+        self.undo_button.setEnabled(False)
+        self.undo_button.setFocusPolicy(Qt.NoFocus)
+
+        # Pause comparison / unpause comparison button
+        self.pause_button = QPushButton(self._container)
+        self.pause_button.setEnabled(False)
+        self.pause_button.setFocusPolicy(Qt.NoFocus)
+
+        self.pause_short_txt = "Pause comp"
+        self.pause_long_txt = "Pause comparison"
+        self.unpause_short_txt = "Unpause comp"
+        self.unpause_long_txt = "Unpause comparison"
+
+        # Reset splits button
+        self.reset_button = QPushButton(self._container)
+        self.reset_button.setFocusPolicy(Qt.NoFocus)
+
+        ##################################
+        #                                #
+        # Widgets (Update available msg) #
+        #                                #
+        ##################################
 
         # Update available message box
-        self.update_available_message_box = QMessageBox(self._container)
-        self.update_available_message_box.setText("New update available!")
-        self.update_available_message_box.setInformativeText(
-            "Pilgrim Autosplitter has been updated!\nOpen the Releases page?"
+        self.update_available_msg = QMessageBox(self._container)
+        self.update_available_msg.setText("New update available!")
+        self.update_available_msg.setInformativeText(
+            "Pilgrim Autosplitter has been updated!\nShow new release?"
         )
-        self.update_available_message_box.setIcon(QMessageBox.Information)
-        self.update_available_message_box.setStandardButtons(
+        self.update_available_msg.setIcon(QMessageBox.Information)
+        self.update_available_msg.setStandardButtons(
             QMessageBox.Open | QMessageBox.Close | QMessageBox.Discard
         )
         # Make sure "Remind me later" button is highlighted
-        self.update_available_message_box.setDefaultButton(
-            self.update_available_message_box.button(QMessageBox.Close)
+        self.update_available_msg.setDefaultButton(
+            self.update_available_msg.button(QMessageBox.Close)
         )
 
         # Update available message box buttons
@@ -420,67 +479,31 @@ class UIMainWindow(QMainWindow):
         # QMessageBox.setStandardButtons, then referencing the buttons by the
         # role they have. If you do that, you can BOTH set the button's text
         # AND make one of the buttons the default.
-        self.update_available_open_button_text = "Open"
-        self._update_available_open_button = self.update_available_message_box.button(
-            QMessageBox.Open
+        self.open_button_txt = "Open"
+        self._open_button = self.update_available_msg.button(QMessageBox.Open)
+        self._open_button.setText(self.open_button_txt)
+
+        self.later_button_txt = "Remind me later"
+        self._later_button = self.update_available_msg.button(QMessageBox.Close)
+        self._later_button.setText(self.later_button_txt)
+
+        self.never_button_txt = "Don't ask again"
+        self._never_button = self.update_available_msg.button(QMessageBox.Discard)
+        self._never_button.setText(self.never_button_txt)
+
+        ##################
+        #                #
+        # Widgets (Misc) #
+        #                #
+        ##################
+
+        # Couldn't find file or directory error message box
+        self.err_not_found_msg = QMessageBox(self)
+        self.err_not_found_msg.setText("File or folder not found")
+        self.err_not_found_msg.setInformativeText(
+            "The file or folder could not be found. Please try again."
         )
-        self._update_available_open_button.setText(
-            self.update_available_open_button_text
-        )
-
-        self.update_available_later_button_text = "Remind me later"
-        self._update_available_later_button = self.update_available_message_box.button(
-            QMessageBox.Close
-        )
-        self._update_available_later_button.setText(
-            self.update_available_later_button_text
-        )
-
-        self.update_available_never_button_text = "Don't ask again"
-        self._update_available_never_button = self.update_available_message_box.button(
-            QMessageBox.Discard
-        )
-        self._update_available_never_button.setText(
-            self.update_available_never_button_text
-        )
-
-        # Reload video button
-        self.reload_video_button = QPushButton("Reconnect video", self._container)
-        self.reload_video_button.setFocusPolicy(Qt.NoFocus)
-
-        # Previous split button
-        self.previous_split_button = QPushButton("<", self._container)
-        self.previous_split_button.setEnabled(False)
-        self.previous_split_button.setFocusPolicy(Qt.NoFocus)
-
-        # Next split button
-        self.next_split_button = QPushButton(">", self._container)
-        self.next_split_button.setEnabled(False)
-        self.next_split_button.setFocusPolicy(Qt.NoFocus)
-
-        # Skip split button
-        self.skip_split_button = QPushButton(self._container)
-        self.skip_split_button.setEnabled(False)
-        self.skip_split_button.setFocusPolicy(Qt.NoFocus)
-
-        # Undo split button
-        self.undo_split_button = QPushButton(self._container)
-        self.undo_split_button.setEnabled(False)
-        self.undo_split_button.setFocusPolicy(Qt.NoFocus)
-
-        # Pause comparison / unpause comparison button
-        self.pause_comparison_button = QPushButton(self._container)
-        self.pause_comparison_button.setEnabled(False)
-        self.pause_comparison_button.setFocusPolicy(Qt.NoFocus)
-
-        self.pause_comparison_button_pause_text_default = "Pause comparison"
-        self.pause_comparison_button_pause_text_truncated = "Pause comp"
-        self.pause_comparison_button_unpause_text_default = "Unpause comparison"
-        self.pause_comparison_button_unpause_text_truncated = "Unpause comp"
-
-        # Reset splits button
-        self.reset_splits_button = QPushButton(self._container)
-        self.reset_splits_button.setFocusPolicy(Qt.NoFocus)
+        self.err_not_found_msg.setIcon(QMessageBox.Warning)
 
         #####################
         #                   #
@@ -496,8 +519,8 @@ class UIMainWindow(QMainWindow):
                 # off to the side). If you just call show, then bafflingly, the
                 # wrong button is highlighted by default. Calling both makes
                 # everything work, for some reason.
-                self.update_available_message_box.show()
-                self.update_available_message_box.open()
+                self.update_available_msg.show()
+                self.update_available_msg.open()
 
 
 class ClickableLineEdit(QLineEdit):

--- a/src/ui/ui_settings_window.py
+++ b/src/ui/ui_settings_window.py
@@ -66,49 +66,49 @@ class UISettingsWindow(QDialog):
     Attributes:
         aspect_ratio_combo_box (QComboBox): Store and allow selection of aspect
             ratio settings.
-        border_helper_frame (QFrame): Draw a border around the edge of the menu
+        border (QFrame): Draw a border around the edge of the menu
             for aesthetic purposes.
         cancel_button (QPushButton): Close the menu without saving. Same as
             clicking the "x button", pressing esc, etc.
         check_for_updates_checkbox (QCheckBox): Enable and disable checking for
             new versions on launch.
         close_window_shortcut (QShortcut): Same as cancel_button.
-        default_delay_double_spinbox (QDoubleSpinBox): Store and allow
+        delay_spinbox (QDoubleSpinBox): Store and allow
             selection of default delay before splitting.
-        default_pause_double_spinbox (QDoubleSpinBox): Store and allow
+        pause_spinbox (QDoubleSpinBox): Store and allow
             selection of default pause after splitting.
-        default_threshold_double_spinbox (QDoubleSpinBox): Store and allow
+        threshold_spinbox (QDoubleSpinBox): Store and allow
             selection of default match percent threshold for triggering a
             split.
         fps_spinbox (QSpinBox): Store and allow selection of default frames per
             second.
         global_hotkeys_checkbox (QCheckBox): Store and allow selection of
             whether global hotkeys are enabled.
-        match_percent_decimals_spinbox (QSpinBox): Store and allow selection of
+        decimals_spinbox (QSpinBox): Store and allow selection of
             amount of decimal places shown when displaying match percents.
-        next_split_hotkey_line_edit (KeyLineEdit): Store and allow selection of
+        next_hotkey_box (KeyLineEdit): Store and allow selection of
             next split hotkey.
         open_screenshots_checkbox (QCheckBox): Store and allow selection of
             whether screenshots are opened when they are captured.
-        pause_hotkey_line_edit (KeyLineEdit): Store and allow selection of
+        pause_hotkey_box (KeyLineEdit): Store and allow selection of
             pause timer hotkey.
-        previous_split_hotkey_line_edit (KeyLineEdit): Store and allow
+        previous_hotkey_box (KeyLineEdit): Store and allow
             selection of previous split hotkey.
-        reset_hotkey_line_edit (KeyLineEdit): Store and allow selection of
+        reset_hotkey_box (KeyLineEdit): Store and allow selection of
             reset splits hotkey.
         save_button (QPushButton): Save all settings and close the window.
-        screenshot_hotkey_line_edit (KeyLineEdit): Store and allow selection of
+        screenshot_hotkey_box (KeyLineEdit): Store and allow selection of
             screenshot hotkey.
-        skip_split_hotkey_line_edit (KeyLineEdit): Store and allow selection of
+        skip_hotkey_box (KeyLineEdit): Store and allow selection of
             skip split hotkey.
-        split_hotkey_line_edit (KeyLineEdit): Store and allow selection
+        split_hotkey_box (KeyLineEdit): Store and allow selection
             of split hotkey.
         start_with_video_checkbox (QCheckBox): Store and allow selection of
             whether this program should try to open a video feed on startup.
         theme_combo_box (QComboBox): Store and allow selection of UI theme.
-        toggle_global_hotkeys_hotkey_line_edit (KeyLineEdit): Store and allow
+        toggle_global_hotkeys_hotkey_box (KeyLineEdit): Store and allow
             selection of toggle global hotkeys enabled hotkey.
-        undo_split_hotkey_line_edit (KeyLineEdit): Store and allow selection of
+        undo_hotkey_box (KeyLineEdit): Store and allow selection of
             undo split hotkey.
     """
 
@@ -125,13 +125,9 @@ class UISettingsWindow(QDialog):
         super().__init__()
 
         # Shift all widgets, except the frame, this many pixels right
-        self._LEFT_EDGE_CORRECTION = 0
+        self._LEFT = 0
         # Shift all widgets, except the frame, this many pixels down
-        self._TOP_EDGE_CORRECTION = 3
-        # Shift the frame this many pixels right
-        self._LEFT_EDGE_CORRECTION_FRAME = 0
-        # Shift the frame this many pixels down
-        self._TOP_EDGE_CORRECTION_FRAME = 0
+        self._TOP = 3
         # Left side widgets are, generally, this many pixels wide
         self._LEFT_SIDE_WIDGET_WIDTH = 70
         # Left side widgets are, generally, this many pixels high
@@ -142,11 +138,11 @@ class UISettingsWindow(QDialog):
 
         self.close_window_shortcut = QShortcut("ctrl+w", self)
 
-        #####################
-        #                   #
-        # Left Side Widgets #
-        #                   #
-        #####################
+        ###########
+        #         #
+        # Widgets #
+        #         #
+        ###########
 
         # Checkbox effect
         self._checkbox_shadow = QGraphicsDropShadowEffect()
@@ -155,48 +151,26 @@ class UISettingsWindow(QDialog):
         self._checkbox_shadow.setColor(QColor(0, 0, 0, 1))
 
         # Border
-        self.border_helper_frame = QFrame(self)
-        self.border_helper_frame.setGeometry(
-            QRect(
-                10 + self._LEFT_EDGE_CORRECTION_FRAME,
-                10 + self._TOP_EDGE_CORRECTION_FRAME,
-                590,
-                372,
-            )
-        )
-        self.border_helper_frame.setAttribute(
-            Qt.WidgetAttribute.WA_TransparentForMouseEvents
-        )
-        self.border_helper_frame.setObjectName("border")
+        self.border = QFrame(self)
+        self.border.setGeometry(QRect(10, 10, 590, 372))
+        self.border.setAttribute(Qt.WidgetAttribute.WA_TransparentForMouseEvents)
+        self.border.setObjectName("border")
 
         # FPS spinbox
         self._fps_label = QLabel("Frames per second:", self)
-        self._fps_label.setGeometry(
-            QRect(
-                20 + self._LEFT_EDGE_CORRECTION, 10 + self._TOP_EDGE_CORRECTION, 131, 31
-            )
-        )
+        self._fps_label.setGeometry(QRect(20 + self._LEFT, 10 + self._TOP, 131, 31))
         self._fps_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
         self._fps_label.setToolTip("Read this many frames per second from video source")
 
         self.fps_spinbox = QSpinBox(self)
-        self.fps_spinbox.setGeometry(
-            QRect(
-                160 + self._LEFT_EDGE_CORRECTION,
-                12 + self._TOP_EDGE_CORRECTION,
-                self._LEFT_SIDE_WIDGET_WIDTH,
-                self._LEFT_SIDE_WIDGET_HEIGHT,
-            )
-        )
+        self.fps_spinbox.setGeometry(QRect(160 + self._LEFT, 12 + self._TOP, 70, 27))
         self.fps_spinbox.setMinimum(20)
         self.fps_spinbox.setMaximum(60)
 
         # Screenshots checkbox
         self._open_screenshots_label = QLabel("Open screenshots:", self)
         self._open_screenshots_label.setGeometry(
-            QRect(
-                20 + self._LEFT_EDGE_CORRECTION, 40 + self._TOP_EDGE_CORRECTION, 141, 31
-            )
+            QRect(20 + self._LEFT, 40 + self._TOP, 141, 31)
         )
         self._open_screenshots_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
         self._open_screenshots_label.setToolTip(
@@ -205,16 +179,12 @@ class UISettingsWindow(QDialog):
 
         self.open_screenshots_checkbox = QCheckBox(self)
         self.open_screenshots_checkbox.setGeometry(
-            QRect(
-                161 + self._LEFT_EDGE_CORRECTION, 49 + self._TOP_EDGE_CORRECTION, 13, 13
-            )
+            QRect(161 + self._LEFT, 49 + self._TOP, 13, 13)
         )
 
         self._open_screenshots_checkbox_helper_label = QLabel(self)
         self._open_screenshots_checkbox_helper_label.setGeometry(
-            QRect(
-                161 + self._LEFT_EDGE_CORRECTION, 48 + self._TOP_EDGE_CORRECTION, 14, 15
-            )
+            QRect(161 + self._LEFT, 48 + self._TOP, 14, 15)
         )
         self._open_screenshots_checkbox_helper_label.setObjectName("checkbox_helper")
         self._open_screenshots_checkbox_helper_label.setAttribute(
@@ -225,131 +195,77 @@ class UISettingsWindow(QDialog):
         )
 
         # Default threshold spinbox
-        self._default_threshold_label = QLabel("Default threshold:", self)
-        self._default_threshold_label.setGeometry(
-            QRect(
-                20 + self._LEFT_EDGE_CORRECTION, 70 + self._TOP_EDGE_CORRECTION, 161, 31
-            )
+        self._threshold_label = QLabel("Default threshold:", self)
+        self._threshold_label.setGeometry(
+            QRect(20 + self._LEFT, 70 + self._TOP, 161, 31)
         )
-        self._default_threshold_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
-        self._default_threshold_label.setToolTip(
+        self._threshold_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        self._threshold_label.setToolTip(
             "Images must match at least this much to trigger a split, pause, etc."
         )
 
-        self.default_threshold_double_spinbox = QDoubleSpinBox(self)
-        self.default_threshold_double_spinbox.setGeometry(
-            QRect(
-                160 + self._LEFT_EDGE_CORRECTION,
-                72 + self._TOP_EDGE_CORRECTION,
-                self._LEFT_SIDE_WIDGET_WIDTH,
-                self._LEFT_SIDE_WIDGET_HEIGHT,
-            )
+        self.threshold_spinbox = QDoubleSpinBox(self)
+        self.threshold_spinbox.setGeometry(
+            QRect(160 + self._LEFT, 72 + self._TOP, 70, 27)
         )
-        self.default_threshold_double_spinbox.setDecimals(2)
-        self.default_threshold_double_spinbox.setMinimum(0.1)
-        self.default_threshold_double_spinbox.setMaximum(100)
-        self.default_threshold_double_spinbox.setSingleStep(0.1)
-        self.default_threshold_double_spinbox.setSuffix("%")
+        self.threshold_spinbox.setDecimals(2)
+        self.threshold_spinbox.setMinimum(0.1)
+        self.threshold_spinbox.setMaximum(100)
+        self.threshold_spinbox.setSingleStep(0.1)
+        self.threshold_spinbox.setSuffix("%")
 
         # Match percent decimals spinbox
-        self._match_percent_decimals_label = QLabel("Similarity decimals:", self)
-        self._match_percent_decimals_label.setGeometry(
-            QRect(
-                20 + self._LEFT_EDGE_CORRECTION,
-                100 + self._TOP_EDGE_CORRECTION,
-                161,
-                31,
-            )
+        self._decimals_label = QLabel("Similarity decimals:", self)
+        self._decimals_label.setGeometry(
+            QRect(20 + self._LEFT, 100 + self._TOP, 161, 31)
         )
-        self._match_percent_decimals_label.setTextInteractionFlags(
-            Qt.TextSelectableByMouse
-        )
-        self._match_percent_decimals_label.setToolTip(
+        self._decimals_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        self._decimals_label.setToolTip(
             "Images must match at least this much to trigger a split, pause, etc."
         )
 
-        self.match_percent_decimals_spinbox = QSpinBox(self)
-        self.match_percent_decimals_spinbox.setGeometry(
-            QRect(
-                160 + self._LEFT_EDGE_CORRECTION,
-                102 + self._TOP_EDGE_CORRECTION,
-                self._LEFT_SIDE_WIDGET_WIDTH,
-                self._LEFT_SIDE_WIDGET_HEIGHT,
-            )
+        self.decimals_spinbox = QSpinBox(self)
+        self.decimals_spinbox.setGeometry(
+            QRect(160 + self._LEFT, 102 + self._TOP, 70, 27)
         )
-        self.match_percent_decimals_spinbox.setMinimum(0)
-        self.match_percent_decimals_spinbox.setMaximum(2)
+        self.decimals_spinbox.setMinimum(0)
+        self.decimals_spinbox.setMaximum(2)
 
         # Default delay spinbox
-        self._default_delay_label = QLabel("Default delay (sec.):", self)
-        self._default_delay_label.setGeometry(
-            QRect(
-                20 + self._LEFT_EDGE_CORRECTION,
-                130 + self._TOP_EDGE_CORRECTION,
-                201,
-                31,
-            )
-        )
-        self._default_delay_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
-        self._default_delay_label.setToolTip(
+        self._delay_label = QLabel("Default delay (sec.):", self)
+        self._delay_label.setGeometry(QRect(20 + self._LEFT, 130 + self._TOP, 201, 31))
+        self._delay_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        self._delay_label.setToolTip(
             "The default delay between the split threshold being reached and a split, pause, etc."
         )
 
-        self.default_delay_double_spinbox = QDoubleSpinBox(self)
-        self.default_delay_double_spinbox.setGeometry(
-            QRect(
-                160 + self._LEFT_EDGE_CORRECTION,
-                132 + self._TOP_EDGE_CORRECTION,
-                self._LEFT_SIDE_WIDGET_WIDTH,
-                self._LEFT_SIDE_WIDGET_HEIGHT,
-            )
-        )
-        self.default_delay_double_spinbox.setDecimals(3)
-        self.default_delay_double_spinbox.setMinimum(0)
-        self.default_delay_double_spinbox.setMaximum(99999)
-        self.default_delay_double_spinbox.setSingleStep(0.1)
+        self.delay_spinbox = QDoubleSpinBox(self)
+        self.delay_spinbox.setGeometry(QRect(160 + self._LEFT, 132 + self._TOP, 70, 27))
+        self.delay_spinbox.setDecimals(3)
+        self.delay_spinbox.setMinimum(0)
+        self.delay_spinbox.setMaximum(99999)
+        self.delay_spinbox.setSingleStep(0.1)
 
         # Default pause spinbox
-        self._default_pause_label = QLabel("Default pause (sec.):", self)
-        self._default_pause_label.setGeometry(
-            QRect(
-                20 + self._LEFT_EDGE_CORRECTION,
-                160 + self._TOP_EDGE_CORRECTION,
-                191,
-                31,
-            )
-        )
-        self._default_pause_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
-        self._default_pause_label.setToolTip(
+        self._pause_label = QLabel("Default pause (sec.):", self)
+        self._pause_label.setGeometry(QRect(20 + self._LEFT, 160 + self._TOP, 191, 31))
+        self._pause_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        self._pause_label.setToolTip(
             "The default waiting period after a split and before starting to compare the next "
             "image. Set this setting higher to save CPU"
         )
 
-        self.default_pause_double_spinbox = QDoubleSpinBox(self)
-        self.default_pause_double_spinbox.setGeometry(
-            QRect(
-                160 + self._LEFT_EDGE_CORRECTION,
-                162 + self._TOP_EDGE_CORRECTION,
-                self._LEFT_SIDE_WIDGET_WIDTH,
-                self._LEFT_SIDE_WIDGET_HEIGHT,
-            )
-        )
-        self.default_pause_double_spinbox.setDecimals(0)
-        # Use a 1 second minimum pause because no pause can cause problems, and
-        # is likely not desireable from a user standpoint anyway
-        self.default_pause_double_spinbox.setMinimum(1)
-        self.default_pause_double_spinbox.setMaximum(99999)
-        self.default_pause_double_spinbox.setSingleStep(1.0)
+        self.pause_spinbox = QDoubleSpinBox(self)
+        self.pause_spinbox.setGeometry(QRect(160 + self._LEFT, 162 + self._TOP, 70, 27))
+        self.pause_spinbox.setDecimals(0)
+        self.pause_spinbox.setMinimum(1)
+        self.pause_spinbox.setMaximum(99999)
+        self.pause_spinbox.setSingleStep(1.0)
 
         # Aspect ratio combobox
         self._aspect_ratio_label = QLabel("GUI aspect ratio:", self)
         self._aspect_ratio_label.setGeometry(
-            QRect(
-                20 + self._LEFT_EDGE_CORRECTION,
-                190 + self._TOP_EDGE_CORRECTION,
-                191,
-                31,
-            )
+            QRect(20 + self._LEFT, 190 + self._TOP, 191, 31)
         )
         self._aspect_ratio_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
         self._aspect_ratio_label.setToolTip(
@@ -359,49 +275,28 @@ class UISettingsWindow(QDialog):
 
         self.aspect_ratio_combo_box = QComboBox(self)
         self.aspect_ratio_combo_box.setGeometry(
-            QRect(
-                160 + self._LEFT_EDGE_CORRECTION,
-                194 + self._TOP_EDGE_CORRECTION,
-                130,
-                self._LEFT_SIDE_WIDGET_HEIGHT - 4,
-            )
+            QRect(160 + self._LEFT, 194 + self._TOP, 130, 23)
         )
         self.aspect_ratio_combo_box.addItems(
             ["4:3 (480x360)", "4:3 (320x240)", "16:9 (512x288)", "16:9 (432x243)"]
         )
+
         # Theme combobox
         self._theme_label = QLabel("Theme:", self)
-        self._theme_label.setGeometry(
-            QRect(
-                20 + self._LEFT_EDGE_CORRECTION,
-                220 + self._TOP_EDGE_CORRECTION,
-                191,
-                31,
-            )
-        )
+        self._theme_label.setGeometry(QRect(20 + self._LEFT, 220 + self._TOP, 191, 31))
         self._theme_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
         self._theme_label.setToolTip("Does anyone actually use light mode?")
 
         self.theme_combo_box = QComboBox(self)
         self.theme_combo_box.setGeometry(
-            QRect(
-                160 + self._LEFT_EDGE_CORRECTION,
-                224 + self._TOP_EDGE_CORRECTION,
-                self._LEFT_SIDE_WIDGET_WIDTH,
-                self._LEFT_SIDE_WIDGET_HEIGHT - 4,
-            )
+            QRect(160 + self._LEFT, 224 + self._TOP, 70, 23)
         )
         self.theme_combo_box.addItems(["dark", "light"])
 
         # Start with video checkbox
         self._start_with_video_label = QLabel("Start with video:", self)
         self._start_with_video_label.setGeometry(
-            QRect(
-                20 + self._LEFT_EDGE_CORRECTION,
-                250 + self._TOP_EDGE_CORRECTION,
-                191,
-                31,
-            )
+            QRect(20 + self._LEFT, 250 + self._TOP, 191, 31)
         )
         self._start_with_video_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
         self._start_with_video_label.setToolTip(
@@ -411,22 +306,12 @@ class UISettingsWindow(QDialog):
 
         self.start_with_video_checkbox = QCheckBox(self)
         self.start_with_video_checkbox.setGeometry(
-            QRect(
-                161 + self._LEFT_EDGE_CORRECTION,
-                259 + self._TOP_EDGE_CORRECTION,
-                13,
-                13,
-            )
+            QRect(161 + self._LEFT, 259 + self._TOP, 13, 13)
         )
 
         self._start_with_video_checkbox_helper_label = QLabel(self)
         self._start_with_video_checkbox_helper_label.setGeometry(
-            QRect(
-                161 + self._LEFT_EDGE_CORRECTION,
-                258 + self._TOP_EDGE_CORRECTION,
-                14,
-                15,
-            )
+            QRect(161 + self._LEFT, 258 + self._TOP, 14, 15)
         )
         self._start_with_video_checkbox_helper_label.setObjectName("checkbox_helper")
         self._start_with_video_checkbox_helper_label.setAttribute(
@@ -439,12 +324,7 @@ class UISettingsWindow(QDialog):
         # Enable global hotkeys checkbox
         self._global_hotkeys_label = QLabel("Global hotkeys:", self)
         self._global_hotkeys_label.setGeometry(
-            QRect(
-                20 + self._LEFT_EDGE_CORRECTION,
-                280 + self._TOP_EDGE_CORRECTION,
-                191,
-                31,
-            )
+            QRect(20 + self._LEFT, 280 + self._TOP, 191, 31)
         )
         self._global_hotkeys_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
         self._global_hotkeys_label.setToolTip(
@@ -453,22 +333,12 @@ class UISettingsWindow(QDialog):
 
         self.global_hotkeys_checkbox = QCheckBox(self)
         self.global_hotkeys_checkbox.setGeometry(
-            QRect(
-                161 + self._LEFT_EDGE_CORRECTION,
-                289 + self._TOP_EDGE_CORRECTION,
-                13,
-                13,
-            )
+            QRect(161 + self._LEFT, 289 + self._TOP, 13, 13)
         )
 
         self._global_hotkeys_checkbox_helper_label = QLabel(self)
         self._global_hotkeys_checkbox_helper_label.setGeometry(
-            QRect(
-                161 + self._LEFT_EDGE_CORRECTION,
-                288 + self._TOP_EDGE_CORRECTION,
-                14,
-                15,
-            )
+            QRect(161 + self._LEFT, 288 + self._TOP, 14, 15)
         )
         self._global_hotkeys_checkbox_helper_label.setObjectName("checkbox_helper")
         self._global_hotkeys_checkbox_helper_label.setAttribute(
@@ -481,12 +351,7 @@ class UISettingsWindow(QDialog):
         # Check for updates checkbox
         self._check_for_updates_label = QLabel("Check for updates:", self)
         self._check_for_updates_label.setGeometry(
-            QRect(
-                20 + self._LEFT_EDGE_CORRECTION,
-                310 + self._TOP_EDGE_CORRECTION,
-                191,
-                31,
-            )
+            QRect(20 + self._LEFT, 310 + self._TOP, 191, 31)
         )
         self._check_for_updates_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
         self._check_for_updates_label.setToolTip(
@@ -495,22 +360,12 @@ class UISettingsWindow(QDialog):
 
         self.check_for_updates_checkbox = QCheckBox(self)
         self.check_for_updates_checkbox.setGeometry(
-            QRect(
-                161 + self._LEFT_EDGE_CORRECTION,
-                319 + self._TOP_EDGE_CORRECTION,
-                13,
-                13,
-            )
+            QRect(161 + self._LEFT, 319 + self._TOP, 13, 13)
         )
 
         self._check_for_updates_checkbox_helper_label = QLabel(self)
         self._check_for_updates_checkbox_helper_label.setGeometry(
-            QRect(
-                161 + self._LEFT_EDGE_CORRECTION,
-                318 + self._TOP_EDGE_CORRECTION,
-                14,
-                15,
-            )
+            QRect(161 + self._LEFT, 318 + self._TOP, 14, 15)
         )
         self._check_for_updates_checkbox_helper_label.setObjectName("checkbox_helper")
         self._check_for_updates_checkbox_helper_label.setAttribute(
@@ -529,345 +384,220 @@ class UISettingsWindow(QDialog):
         # Hotkey header
         self._hotkey_settings_label = QLabel("Hotkeys (click + type to change):", self)
         self._hotkey_settings_label.setGeometry(
-            QRect(
-                300 + self._LEFT_EDGE_CORRECTION,
-                10 + self._TOP_EDGE_CORRECTION,
-                216,
-                31,
-            )
+            QRect(300 + self._LEFT, 10 + self._TOP, 216, 31)
         )
         self._hotkey_settings_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
 
         # Split hotkey
-        self.split_hotkey_line_edit = KeyLineEdit(self)
-        self.split_hotkey_line_edit.setGeometry(
-            QRect(
-                410 + self._LEFT_EDGE_CORRECTION,
-                42 + self._TOP_EDGE_CORRECTION,
-                121,
-                25,
-            )
+        self.split_hotkey_box = KeyLineEdit(self)
+        self.split_hotkey_box.setGeometry(
+            QRect(410 + self._LEFT, 42 + self._TOP, 121, 25)
         )
-        self.split_hotkey_line_edit.setReadOnly(True)
+        self.split_hotkey_box.setReadOnly(True)
 
         self._split_hotkey_label = QLabel("Split", self)
         self._split_hotkey_label.setGeometry(
-            QRect(
-                300 + self._LEFT_EDGE_CORRECTION, 40 + self._TOP_EDGE_CORRECTION, 81, 31
-            )
+            QRect(300 + self._LEFT, 40 + self._TOP, 81, 31)
         )
         self._split_hotkey_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
 
         self._split_hotkey_clear_button = QPushButton("clear", self)
         self._split_hotkey_clear_button.setGeometry(
-            QRect(
-                545 + self._LEFT_EDGE_CORRECTION, 45 + self._TOP_EDGE_CORRECTION, 39, 20
-            )
+            QRect(545 + self._LEFT, 45 + self._TOP, 39, 20)
         )
         self._split_hotkey_clear_button.setFocusPolicy(Qt.NoFocus)
         self._split_hotkey_clear_button.clicked.connect(
-            lambda: self.split_hotkey_line_edit.setText("")
+            lambda: self.split_hotkey_box.setText("")
         )
         self._split_hotkey_clear_button.clicked.connect(
-            lambda: setattr(self.split_hotkey_line_edit, "key_code", "")
+            lambda: setattr(self.split_hotkey_box, "key_code", "")
         )
 
         # Reset splits hotkey
-        self.reset_hotkey_line_edit = KeyLineEdit(self)
-        self.reset_hotkey_line_edit.setGeometry(
-            QRect(
-                410 + self._LEFT_EDGE_CORRECTION,
-                72 + self._TOP_EDGE_CORRECTION,
-                121,
-                25,
-            )
+        self.reset_hotkey_box = KeyLineEdit(self)
+        self.reset_hotkey_box.setGeometry(
+            QRect(410 + self._LEFT, 72 + self._TOP, 121, 25)
         )
-        self.reset_hotkey_line_edit.setReadOnly(True)
+        self.reset_hotkey_box.setReadOnly(True)
 
         self._reset_hotkey_label = QLabel("Reset splits", self)
         self._reset_hotkey_label.setGeometry(
-            QRect(
-                300 + self._LEFT_EDGE_CORRECTION, 70 + self._TOP_EDGE_CORRECTION, 91, 31
-            )
+            QRect(300 + self._LEFT, 70 + self._TOP, 91, 31)
         )
         self._reset_hotkey_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
 
         self._reset_hotkey_clear_button = QPushButton("clear", self)
         self._reset_hotkey_clear_button.setGeometry(
-            QRect(
-                545 + self._LEFT_EDGE_CORRECTION, 75 + self._TOP_EDGE_CORRECTION, 39, 20
-            )
+            QRect(545 + self._LEFT, 75 + self._TOP, 39, 20)
         )
         self._reset_hotkey_clear_button.setFocusPolicy(Qt.NoFocus)
         self._reset_hotkey_clear_button.clicked.connect(
-            lambda: self.reset_hotkey_line_edit.setText("")
+            lambda: self.reset_hotkey_box.setText("")
         )
         self._reset_hotkey_clear_button.clicked.connect(
-            lambda: setattr(self.reset_hotkey_line_edit, "key_code", "")
+            lambda: setattr(self.reset_hotkey_box, "key_code", "")
         )
 
         # Pause hotkey
-        self.pause_hotkey_line_edit = KeyLineEdit(self)
-        self.pause_hotkey_line_edit.setGeometry(
-            QRect(
-                410 + self._LEFT_EDGE_CORRECTION,
-                102 + self._TOP_EDGE_CORRECTION,
-                121,
-                25,
-            )
+        self.pause_hotkey_box = KeyLineEdit(self)
+        self.pause_hotkey_box.setGeometry(
+            QRect(410 + self._LEFT, 102 + self._TOP, 121, 25)
         )
-        self.pause_hotkey_line_edit.setReadOnly(True)
+        self.pause_hotkey_box.setReadOnly(True)
 
         self._pause_hotkey_label = QLabel("Pause timer", self)
         self._pause_hotkey_label.setGeometry(
-            QRect(
-                300 + self._LEFT_EDGE_CORRECTION,
-                100 + self._TOP_EDGE_CORRECTION,
-                91,
-                31,
-            )
+            QRect(300 + self._LEFT, 100 + self._TOP, 91, 31)
         )
         self._pause_hotkey_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
 
         self._pause_hotkey_clear_button = QPushButton("clear", self)
         self._pause_hotkey_clear_button.setGeometry(
-            QRect(
-                545 + self._LEFT_EDGE_CORRECTION,
-                105 + self._TOP_EDGE_CORRECTION,
-                39,
-                20,
-            )
+            QRect(545 + self._LEFT, 105 + self._TOP, 39, 20)
         )
         self._pause_hotkey_clear_button.setFocusPolicy(Qt.NoFocus)
         self._pause_hotkey_clear_button.clicked.connect(
-            lambda: self.pause_hotkey_line_edit.setText("")
+            lambda: self.pause_hotkey_box.setText("")
         )
         self._pause_hotkey_clear_button.clicked.connect(
-            lambda: setattr(self.pause_hotkey_line_edit, "key_code", "")
+            lambda: setattr(self.pause_hotkey_box, "key_code", "")
         )
 
         # Undo split hotkey
-        self.undo_split_hotkey_line_edit = KeyLineEdit(self)
-        self.undo_split_hotkey_line_edit.setGeometry(
-            QRect(
-                410 + self._LEFT_EDGE_CORRECTION,
-                132 + self._TOP_EDGE_CORRECTION,
-                121,
-                25,
-            )
+        self.undo_hotkey_box = KeyLineEdit(self)
+        self.undo_hotkey_box.setGeometry(
+            QRect(410 + self._LEFT, 132 + self._TOP, 121, 25)
         )
-        self.undo_split_hotkey_line_edit.setReadOnly(True)
+        self.undo_hotkey_box.setReadOnly(True)
 
-        self._undo_split_hotkey_label = QLabel("Undo split", self)
-        self._undo_split_hotkey_label.setGeometry(
-            QRect(
-                300 + self._LEFT_EDGE_CORRECTION,
-                130 + self._TOP_EDGE_CORRECTION,
-                81,
-                31,
-            )
+        self._undo_hotkey_label = QLabel("Undo split", self)
+        self._undo_hotkey_label.setGeometry(
+            QRect(300 + self._LEFT, 130 + self._TOP, 81, 31)
         )
-        self._undo_split_hotkey_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        self._undo_hotkey_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
 
-        self._undo_split_hotkey_clear_button = QPushButton("clear", self)
-        self._undo_split_hotkey_clear_button.setGeometry(
-            QRect(
-                545 + self._LEFT_EDGE_CORRECTION,
-                135 + self._TOP_EDGE_CORRECTION,
-                39,
-                20,
-            )
+        self._undo_hotkey_clear_button = QPushButton("clear", self)
+        self._undo_hotkey_clear_button.setGeometry(
+            QRect(545 + self._LEFT, 135 + self._TOP, 39, 20)
         )
-        self._undo_split_hotkey_clear_button.setFocusPolicy(Qt.NoFocus)
-        self._undo_split_hotkey_clear_button.clicked.connect(
-            lambda: self.undo_split_hotkey_line_edit.setText("")
+        self._undo_hotkey_clear_button.setFocusPolicy(Qt.NoFocus)
+        self._undo_hotkey_clear_button.clicked.connect(
+            lambda: self.undo_hotkey_box.setText("")
         )
-        self._undo_split_hotkey_clear_button.clicked.connect(
-            lambda: setattr(self.undo_split_hotkey_line_edit, "key_code", "")
+        self._undo_hotkey_clear_button.clicked.connect(
+            lambda: setattr(self.undo_hotkey_box, "key_code", "")
         )
 
         # Skip split hotkey
-        self.skip_split_hotkey_line_edit = KeyLineEdit(self)
-        self.skip_split_hotkey_line_edit.setGeometry(
-            QRect(
-                410 + self._LEFT_EDGE_CORRECTION,
-                162 + self._TOP_EDGE_CORRECTION,
-                121,
-                25,
-            )
+        self.skip_hotkey_box = KeyLineEdit(self)
+        self.skip_hotkey_box.setGeometry(
+            QRect(410 + self._LEFT, 162 + self._TOP, 121, 25)
         )
-        self.skip_split_hotkey_line_edit.setReadOnly(True)
+        self.skip_hotkey_box.setReadOnly(True)
 
-        self._skip_split_hotkey_label = QLabel("Skip split", self)
-        self._skip_split_hotkey_label.setGeometry(
-            QRect(
-                300 + self._LEFT_EDGE_CORRECTION,
-                160 + self._TOP_EDGE_CORRECTION,
-                71,
-                31,
-            )
+        self._skip_hotkey_label = QLabel("Skip split", self)
+        self._skip_hotkey_label.setGeometry(
+            QRect(300 + self._LEFT, 160 + self._TOP, 71, 31)
         )
-        self._skip_split_hotkey_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        self._skip_hotkey_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
 
-        self._skip_split_hotkey_clear_button = QPushButton("clear", self)
-        self._skip_split_hotkey_clear_button.setGeometry(
-            QRect(
-                545 + self._LEFT_EDGE_CORRECTION,
-                165 + self._TOP_EDGE_CORRECTION,
-                39,
-                20,
-            )
+        self._skip_hotkey_clear_button = QPushButton("clear", self)
+        self._skip_hotkey_clear_button.setGeometry(
+            QRect(545 + self._LEFT, 165 + self._TOP, 39, 20)
         )
-        self._skip_split_hotkey_clear_button.setFocusPolicy(Qt.NoFocus)
-        self._skip_split_hotkey_clear_button.clicked.connect(
-            lambda: self.skip_split_hotkey_line_edit.setText("")
+        self._skip_hotkey_clear_button.setFocusPolicy(Qt.NoFocus)
+        self._skip_hotkey_clear_button.clicked.connect(
+            lambda: self.skip_hotkey_box.setText("")
         )
-        self._skip_split_hotkey_clear_button.clicked.connect(
-            lambda: setattr(self.skip_split_hotkey_line_edit, "key_code", "")
+        self._skip_hotkey_clear_button.clicked.connect(
+            lambda: setattr(self.skip_hotkey_box, "key_code", "")
         )
 
         # Previous split hotkey
-        self.previous_split_hotkey_line_edit = KeyLineEdit(self)
-        self.previous_split_hotkey_line_edit.setGeometry(
-            QRect(
-                410 + self._LEFT_EDGE_CORRECTION,
-                192 + self._TOP_EDGE_CORRECTION,
-                121,
-                25,
-            )
+        self.previous_hotkey_box = KeyLineEdit(self)
+        self.previous_hotkey_box.setGeometry(
+            QRect(410 + self._LEFT, 192 + self._TOP, 121, 25)
         )
-        self.previous_split_hotkey_line_edit.setReadOnly(True)
+        self.previous_hotkey_box.setReadOnly(True)
 
-        self._previous_split_hotkey_label = QLabel("Previous split", self)
-        self._previous_split_hotkey_label.setGeometry(
-            QRect(
-                300 + self._LEFT_EDGE_CORRECTION,
-                190 + self._TOP_EDGE_CORRECTION,
-                101,
-                31,
-            )
+        self._previous_hotkey_label = QLabel("Previous split", self)
+        self._previous_hotkey_label.setGeometry(
+            QRect(300 + self._LEFT, 190 + self._TOP, 101, 31)
         )
-        self._previous_split_hotkey_label.setTextInteractionFlags(
-            Qt.TextSelectableByMouse
-        )
+        self._previous_hotkey_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
 
-        self._previous_split_hotkey_clear_button = QPushButton("clear", self)
-        self._previous_split_hotkey_clear_button.setGeometry(
-            QRect(
-                545 + self._LEFT_EDGE_CORRECTION,
-                195 + self._TOP_EDGE_CORRECTION,
-                39,
-                20,
-            )
+        self._previous_hotkey_clear_button = QPushButton("clear", self)
+        self._previous_hotkey_clear_button.setGeometry(
+            QRect(545 + self._LEFT, 195 + self._TOP, 39, 20)
         )
-        self._previous_split_hotkey_clear_button.setFocusPolicy(Qt.NoFocus)
-        self._previous_split_hotkey_clear_button.clicked.connect(
-            lambda: self.previous_split_hotkey_line_edit.setText("")
+        self._previous_hotkey_clear_button.setFocusPolicy(Qt.NoFocus)
+        self._previous_hotkey_clear_button.clicked.connect(
+            lambda: self.previous_hotkey_box.setText("")
         )
-        self._previous_split_hotkey_clear_button.clicked.connect(
-            lambda: setattr(self.previous_split_hotkey_line_edit, "key_code", "")
+        self._previous_hotkey_clear_button.clicked.connect(
+            lambda: setattr(self.previous_hotkey_box, "key_code", "")
         )
 
         # Next split hotkey
-        self.next_split_hotkey_line_edit = KeyLineEdit(self)
-        self.next_split_hotkey_line_edit.setGeometry(
-            QRect(
-                410 + self._LEFT_EDGE_CORRECTION,
-                222 + self._TOP_EDGE_CORRECTION,
-                121,
-                25,
-            )
+        self.next_hotkey_box = KeyLineEdit(self)
+        self.next_hotkey_box.setGeometry(
+            QRect(410 + self._LEFT, 222 + self._TOP, 121, 25)
         )
-        self.next_split_hotkey_line_edit.setReadOnly(True)
+        self.next_hotkey_box.setReadOnly(True)
 
-        self._next_split_hotkey_label = QLabel("Next split", self)
-        self._next_split_hotkey_label.setGeometry(
-            QRect(
-                300 + self._LEFT_EDGE_CORRECTION,
-                220 + self._TOP_EDGE_CORRECTION,
-                71,
-                31,
-            )
+        self._next_hotkey_label = QLabel("Next split", self)
+        self._next_hotkey_label.setGeometry(
+            QRect(300 + self._LEFT, 220 + self._TOP, 71, 31)
         )
-        self._next_split_hotkey_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        self._next_hotkey_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
 
-        self._next_split_hotkey_clear_button = QPushButton("clear", self)
-        self._next_split_hotkey_clear_button.setGeometry(
-            QRect(
-                545 + self._LEFT_EDGE_CORRECTION,
-                225 + self._TOP_EDGE_CORRECTION,
-                39,
-                20,
-            )
+        self._next_hotkey_clear_button = QPushButton("clear", self)
+        self._next_hotkey_clear_button.setGeometry(
+            QRect(545 + self._LEFT, 225 + self._TOP, 39, 20)
         )
-        self._next_split_hotkey_clear_button.setFocusPolicy(Qt.NoFocus)
-        self._next_split_hotkey_clear_button.clicked.connect(
-            lambda: self.next_split_hotkey_line_edit.setText("")
+        self._next_hotkey_clear_button.setFocusPolicy(Qt.NoFocus)
+        self._next_hotkey_clear_button.clicked.connect(
+            lambda: self.next_hotkey_box.setText("")
         )
-        self._next_split_hotkey_clear_button.clicked.connect(
-            lambda: setattr(self.next_split_hotkey_line_edit, "key_code", "")
+        self._next_hotkey_clear_button.clicked.connect(
+            lambda: setattr(self.next_hotkey_box, "key_code", "")
         )
 
         # Screenshot hotkey
-        self.screenshot_hotkey_line_edit = KeyLineEdit(self)
-        self.screenshot_hotkey_line_edit.setGeometry(
-            QRect(
-                410 + self._LEFT_EDGE_CORRECTION,
-                252 + self._TOP_EDGE_CORRECTION,
-                121,
-                25,
-            )
+        self.screenshot_hotkey_box = KeyLineEdit(self)
+        self.screenshot_hotkey_box.setGeometry(
+            QRect(410 + self._LEFT, 252 + self._TOP, 121, 25)
         )
-        self.screenshot_hotkey_line_edit.setReadOnly(True)
+        self.screenshot_hotkey_box.setReadOnly(True)
 
         self._screenshot_hotkey_label = QLabel("Screenshot", self)
         self._screenshot_hotkey_label.setGeometry(
-            QRect(
-                300 + self._LEFT_EDGE_CORRECTION,
-                250 + self._TOP_EDGE_CORRECTION,
-                71,
-                31,
-            )
+            QRect(300 + self._LEFT, 250 + self._TOP, 71, 31)
         )
         self._screenshot_hotkey_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
 
         self._screenshot_hotkey_clear_button = QPushButton("clear", self)
         self._screenshot_hotkey_clear_button.setGeometry(
-            QRect(
-                545 + self._LEFT_EDGE_CORRECTION,
-                255 + self._TOP_EDGE_CORRECTION,
-                39,
-                20,
-            )
+            QRect(545 + self._LEFT, 255 + self._TOP, 39, 20)
         )
         self._screenshot_hotkey_clear_button.setFocusPolicy(Qt.NoFocus)
         self._screenshot_hotkey_clear_button.clicked.connect(
-            lambda: self.screenshot_hotkey_line_edit.setText("")
+            lambda: self.screenshot_hotkey_box.setText("")
         )
         self._screenshot_hotkey_clear_button.clicked.connect(
-            lambda: setattr(self.screenshot_hotkey_line_edit, "key_code", "")
+            lambda: setattr(self.screenshot_hotkey_box, "key_code", "")
         )
 
         # Toggle global hotkeys hotkey
-        self.toggle_global_hotkeys_hotkey_line_edit = KeyLineEdit(self)
-        self.toggle_global_hotkeys_hotkey_line_edit.setGeometry(
-            QRect(
-                410 + self._LEFT_EDGE_CORRECTION,
-                282 + self._TOP_EDGE_CORRECTION,
-                121,
-                25,
-            )
+        self.toggle_global_hotkeys_hotkey_box = KeyLineEdit(self)
+        self.toggle_global_hotkeys_hotkey_box.setGeometry(
+            QRect(410 + self._LEFT, 282 + self._TOP, 121, 25)
         )
-        self.toggle_global_hotkeys_hotkey_line_edit.setReadOnly(True)
+        self.toggle_global_hotkeys_hotkey_box.setReadOnly(True)
 
         self._toggle_global_hotkeys_hotkey_label = QLabel("Toggle global", self)
         self._toggle_global_hotkeys_hotkey_label.setGeometry(
-            QRect(
-                300 + self._LEFT_EDGE_CORRECTION,
-                280 + self._TOP_EDGE_CORRECTION,
-                100,
-                31,
-            )
+            QRect(300 + self._LEFT, 280 + self._TOP, 100, 31)
         )
         self._toggle_global_hotkeys_hotkey_label.setTextInteractionFlags(
             Qt.TextSelectableByMouse
@@ -875,43 +605,26 @@ class UISettingsWindow(QDialog):
 
         self._toggle_global_hotkeys_hotkey_clear_button = QPushButton("clear", self)
         self._toggle_global_hotkeys_hotkey_clear_button.setGeometry(
-            QRect(
-                545 + self._LEFT_EDGE_CORRECTION,
-                285 + self._TOP_EDGE_CORRECTION,
-                39,
-                20,
-            )
+            QRect(545 + self._LEFT, 285 + self._TOP, 39, 20)
         )
         self._toggle_global_hotkeys_hotkey_clear_button.setFocusPolicy(Qt.NoFocus)
         self._toggle_global_hotkeys_hotkey_clear_button.clicked.connect(
-            lambda: self.toggle_global_hotkeys_hotkey_line_edit.setText("")
+            lambda: self.toggle_global_hotkeys_hotkey_box.setText("")
         )
         self._toggle_global_hotkeys_hotkey_clear_button.clicked.connect(
-            lambda: setattr(self.toggle_global_hotkeys_hotkey_line_edit, "key_code", "")
+            lambda: setattr(self.toggle_global_hotkeys_hotkey_box, "key_code", "")
         )
 
         # Cancel button
         self.cancel_button = QPushButton("Cancel", self)
         self.cancel_button.setGeometry(
-            QRect(
-                319 + self._LEFT_EDGE_CORRECTION,
-                326 + self._TOP_EDGE_CORRECTION,
-                111,
-                31,
-            )
+            QRect(319 + self._LEFT, 326 + self._TOP, 111, 31)
         )
         self.cancel_button.setFocusPolicy(Qt.NoFocus)
 
         # Save button
         self.save_button = QPushButton("Save", self)
-        self.save_button.setGeometry(
-            QRect(
-                459 + self._LEFT_EDGE_CORRECTION,
-                326 + self._TOP_EDGE_CORRECTION,
-                111,
-                31,
-            )
-        )
+        self.save_button.setGeometry(QRect(459 + self._LEFT, 326 + self._TOP, 111, 31))
         self.save_button.setFocusPolicy(Qt.NoFocus)
 
     def event(self, event) -> Union[bool, QWidget.event]:

--- a/src/ui/ui_settings_window.py
+++ b/src/ui/ui_settings_window.py
@@ -164,7 +164,7 @@ class UISettingsWindow(QDialog):
 
         self.fps_spinbox = QSpinBox(self)
         self.fps_spinbox.setGeometry(QRect(160 + self._LEFT, 12 + self._TOP, 70, 27))
-        self.fps_spinbox.setMinimum(20)
+        self.fps_spinbox.setMinimum(10)
         self.fps_spinbox.setMaximum(60)
 
         # Screenshots checkbox

--- a/src/ui/ui_style_sheet.py
+++ b/src/ui/ui_style_sheet.py
@@ -133,7 +133,7 @@ style_sheet_dark = Template(
         background: #555555;
         border: 1px solid $text_and_borders;
     }
-    QLabel#split_image_overlay {
+    QLabel#split_overlay {
         background-color: rgba(134, 134, 134, 0.7);
         border: 1px solid $text_and_borders;
     }
@@ -247,7 +247,7 @@ style_sheet_light = Template(
         background: #bbbbbb;
         border: 1px solid $text_and_borders;
     }
-    QLabel#split_image_overlay {
+    QLabel#split_overlay {
         background-color: rgba(134, 134, 134, 0.7);
         border: 1px solid $text_and_borders;
     }


### PR DESCRIPTION
Very messy changelog:

Whole program:
Make default loop count 1 instead of 0. 1 = the split image doesn't repeat, 2 = it repeats once, etc.
Shorten various attribute and variable names

settings -- change version to v1.0.4
                   Change default FPS to 30

split_dir -- remove self.ignore_split_request -- this is no longer needed because we can account for times when the split hotkey isn't caught, so we know split always goes forward exactly 1 image per split (see ui_controller._execute_split_action)

splitter -- never delay after last split
                  remove start/split thread (see notes on split_dir -- no longer needed since we always go forward exactly 1)

ui_controller -- Kill compare_thread when split hotkey is pressed on last split.
remove all flags storing update_ui state, except for self._redraw_split_labels, which is now set every time request_reset, request_next, or request_previous is called, when the aspect ratio is changed, or when min view is toggled, since these are all the cases in which a split image changes.
Use (self._splitter.match_percent is None) instead of (self._splitter.delaying or self._splitter.suspended) to determine whether request_next and request_previous should try to pause the splitter, since there is a very small chance that (self._splitter.delaying or self._splitter.suspended) could be false when splitter.look_for_match is inactive (e.g. right when setting split flags).
Remove self._settings_window_showing, because we can just check the value of settings_window.isVisible instead.
Rewrite _handle_hotkey_press to increase readability and save space
Rewrite _set_button_and_label_text so that button text can be more easily modified from ui_main_window
Prevent poller from polling at fewer than 20 Hz

ui_main_window -- reorganize the order of code in __init__ for readability

ui_settings_window -- reorganize the order of code in __init__ for readability
                                       lower minimum FPS to 10