### PR TITLE
v1.0.7 (Rework keyboard)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 **/_site
 **/.jekyll-cache
 pilgrim_autosplitter.spec
+**/.pytest_cache

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,3 @@
 **/_site
 **/.jekyll-cache
 pilgrim_autosplitter.spec
-

--- a/README.md
+++ b/README.md
@@ -47,19 +47,20 @@ Download the latest Windows build (Pilgrim.Autosplitter.Windows.v1.x.x) from the
 
 If you're familiar with Python:
 
-* Make sure you have Python 3.10+ installed
+* Make sure you have Python 3.8+ installed (Python 3.11+ is recommended for an optimal experience)
 
 * Run `python -m pip install -r requirements.txt`
 
 > [!Note]
 > If installation hangs up when trying to download PyQt5, try running the following command: `python -m pip install pyqt5 --config-settings --confirm-license= --verbose`.
 > Some users (including myself) have experienced a softlock when verifying the PyQt5 license; this should solve that problem.
+> In addition, if using Python <=3.10, you may need to manually install PyQt5 using `python -m pip install pyqt5-tools`.
 
 * Open the app with `python pilgrim_autosplitter.py`
 
 If this is your first time using Python:
 
-* Install the latest version of Python (3.12 at this time) by clicking [here](https://www.python.org/downloads/).
+* Install the latest stable Python release (3.12 at this time) by clicking [here](https://www.python.org/downloads/).
 
 > [!Important]
 > When installing Python using the Python installer, you MUST check the box next to `Add Python to PATH`. If you don't, the next part won't work.
@@ -100,19 +101,20 @@ Known limitations:
 
 If you're familiar with Python:
 
-* Make sure you have Python 3.10+ installed
+* Make sure you have Python 3.8+ installed (Python 3.11+ is recommended for an optimal experience)
 
 * Run `pip3 install -r requirements.txt`
 
 > [!Note]
 > If installation hangs up when trying to download PyQt5, try running the following command: `python -m pip install pyqt5 --config-settings --confirm-license= --verbose`.
 > Some users (including myself) have experienced a softlock when verifying the PyQt5 license; this should solve that problem.
+> In addition, if using Python <=3.10, you may need to manually install PyQt5 using `python -m pip install pyqt5-tools`.
 
 * Open the app with `python3 pilgrim_autosplitter.py`
 
 If this is your first time using Python:
 
-* Install the latest version of Python (3.12 at this time) by clicking [here](https://www.python.org/downloads/).
+* Install the latest stable Python release (3.12 at this time) by clicking [here](https://www.python.org/downloads/).
 
 * Download Pilgrim Autosplitter's source code from the [most recent release](https://github.com/pilgrimtabby/pilgrim-autosplitter/releases/latest) (click on `Source code (zip)` or `Source code (tar.gz)`). Extract the files.
 
@@ -134,8 +136,9 @@ Known limitations:
 
 ### Method 2: Run from source with Python
 
-If you're on Linux, I assume you know what you're doing. Get the latest release [here](https://github.com/pilgrimtabby/pilgrim-autosplitter/releases/latest), use pip to install the dependencies in `requirements-linux.txt`, and run `src/pilgrim_autosplitter.py` as root. Python >=3.10 is required.
+If you're on Linux, I assume you know what you're doing. Get the latest release [here](https://github.com/pilgrimtabby/pilgrim-autosplitter/releases/latest), use pip to install the dependencies in `requirements-linux.txt`, and run `src/pilgrim_autosplitter.py` as root. Python >=3.8 is required (Python 3.11+ is recommended for an optimal experience).
 
 > [!Note]
 > If installation hangs up when trying to download PyQt5, try running the following command: `python -m pip install pyqt5 --config-settings --confirm-license= --verbose`.
 > Some users (including myself) have experienced a softlock when verifying the PyQt5 license; this should solve that problem.
+> In addition, if using Python <=3.10, you may need to manually install PyQt5 using `python -m pip install pyqt5-tools`.

--- a/requirements-linux.txt
+++ b/requirements-linux.txt
@@ -3,4 +3,5 @@ opencv-python-headless>=4.9.0.80
 keyboard>=0.13.5
 PyQt5>=5.15.10
 PyQt5-sip>=12.13.0
+pytest>=8.3.2
 requests>=2.32.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ opencv-python>=4.9.0.80
 pynput>=1.7.6
 PyQt5>=5.15.10
 PyQt5-sip>=12.13.0
+pytest>=8.3.2
 requests>=2.32.3

--- a/src/pilgrim_autosplitter.py
+++ b/src/pilgrim_autosplitter.py
@@ -89,7 +89,7 @@ class PilgrimAutosplitter:
                 QIcon(QPixmap(f"{program_directory}/../resources/icon-macos.png"))
             )
 
-        settings.set_defaults()
+        settings.set_program_vals()
 
         self.splitter = Splitter()
         if settings.get_bool("START_WITH_VIDEO"):

--- a/src/settings.py
+++ b/src/settings.py
@@ -133,8 +133,11 @@ def set_value(key: str, value: any, settings: QSettings = settings) -> None:
     settings.setValue(key, str(value))
 
 
-def set_defaults(settings: QSettings = settings) -> None:
-    """Ensure that settings values make sense before they are used.
+def set_program_vals(settings: QSettings = settings) -> None:
+    """Ensure that settings values are updated and make sense before use.
+
+    Unsets hotkeys if last used version was <=1.0.6 due to a change in the way
+    hotkeys are implemented.
 
     Populates settings with default values if they have not yet been set.
 
@@ -146,138 +149,149 @@ def set_defaults(settings: QSettings = settings) -> None:
     Makes sure that the correct aspect ratio is shown.
     """
     home_dir = get_home_dir()
-    if not get_bool("SETTINGS_SET", settings=settings):
-        # Indicate whether default settings have been populated
-        set_value("SETTINGS_SET", True, settings=settings)
+
+    # Unset hotkeys if upgrading from <=v1.0.6 because of hotkey implementation
+    # updates
+    last_version = get_str("LAST_VERSION", settings)
+    if last_version == "None":
+        last_version = "v1.0.0"
+    if not version_ge(last_version, "v1.0.7"):
+        unset_hotkey_bindings()
+
+    if not get_bool("SETTINGS_SET", settings):
+        # Indicate that default settings have been populated
+        set_value("SETTINGS_SET", True, settings)
+
+        # Set hotkeys to default values
+        unset_hotkey_bindings()
 
         # The default minimum match percent needed to force a split action
-        set_value("DEFAULT_THRESHOLD", 0.90, settings=settings)
+        set_value("DEFAULT_THRESHOLD", 0.90, settings)
 
         # The default delay (seconds) before a split
-        set_value("DEFAULT_DELAY", 0.0, settings=settings)
+        set_value("DEFAULT_DELAY", 0.0, settings)
 
         # The default pause (seconds) after a split
-        set_value("DEFAULT_PAUSE", 1.0, settings=settings)
+        set_value("DEFAULT_PAUSE", 1.0, settings)
 
         # The FPS used by splitter and ui_controller
-        set_value("FPS", 30, settings=settings)
+        set_value("FPS", 30, settings)
 
         # The location of split images
-        set_value("LAST_IMAGE_DIR", home_dir, settings=settings)
+        set_value("LAST_IMAGE_DIR", home_dir, settings)
 
         # Determine whether screenshots should be opened using the machine's
         # default image viewer after capture
-        set_value("OPEN_SCREENSHOT_ON_CAPTURE", False, settings=settings)
+        set_value("OPEN_SCREENSHOT_ON_CAPTURE", False, settings)
 
         # The number of decimal places shown when displaying match percents
-        set_value("MATCH_PERCENT_DECIMALS", 0, settings=settings)
-
-        # The text value of the split hotkey
-        set_value("SPLIT_HOTKEY_NAME", "", settings=settings)
-
-        # The text value of the reset hotkey
-        set_value("RESET_HOTKEY_NAME", "", settings=settings)
-
-        # The text value of the pause hotkey
-        set_value("PAUSE_HOTKEY_NAME", "", settings=settings)
-
-        # The text value of the undo hotkey
-        set_value("UNDO_HOTKEY_NAME", "", settings=settings)
-
-        # The text value of the skip split hotkey
-        set_value("SKIP_HOTKEY_NAME", "", settings=settings)
-
-        # The text value of the previous split hotkey
-        set_value("PREV_HOTKEY_NAME", "", settings=settings)
-
-        # The text value of the next split hotkey
-        set_value("NEXT_HOTKEY_NAME", "", settings=settings)
-
-        # The text value of the screenshot hotkey
-        set_value("SCREENSHOT_HOTKEY_NAME", "", settings=settings)
-
-        # The text value of the toggle global hotkeys hotkey
-        set_value("TOGGLE_HOTKEYS_HOTKEY_NAME", "", settings=settings)
-
-        # The pynput.keyboard.Key.vk value of the split hotkey
-        set_value("SPLIT_HOTKEY_CODE", "")
-
-        # The pynput.keyboard.Key.vk value of the reset hotkey
-        set_value("RESET_HOTKEY_CODE", "", settings=settings)
-
-        # The pynput.keyboard.Key.vk value of the pause hotkey
-        set_value("PAUSE_HOTKEY_CODE", "", settings=settings)
-
-        # The pynput.keyboard.Key.vk value of the undo split hotkey
-        set_value("UNDO_HOTKEY_CODE", "", settings=settings)
-
-        # The pynput.keyboard.Key.vk value of the skip split hotkey
-        set_value("SKIP_HOTKEY_CODE", "", settings=settings)
-
-        # The pynput.keyboard.Key.vk value of the previous split hotkey
-        set_value("PREV_HOTKEY_CODE", "", settings=settings)
-
-        # The pynput.keyboard.Key.vk value of the next split hotkey
-        set_value("NEXT_HOTKEY_CODE", "", settings=settings)
-
-        # The pynput.keyboard.Key.vk value of the screenshot hotkey
-        set_value("SCREENSHOT_HOTKEY_CODE", "", settings=settings)
-
-        # The pynput.keyboard.Key.vk value of the toggle global hotkeys hotkey
-        set_value("TOGGLE_HOTKEYS_HOTKEY_CODE", "", settings=settings)
+        set_value("MATCH_PERCENT_DECIMALS", 0, settings)
 
         # The UI theme
-        set_value("THEME", "dark", settings=settings)
+        set_value("THEME", "dark", settings)
 
         # The aspect ratio
-        set_value("ASPECT_RATIO", "4:3 (480x360)", settings=settings)
+        set_value("ASPECT_RATIO", "4:3 (480x360)", settings)
 
         # Always on top value
-        set_value("ALWAYS_ON_TOP", False, settings=settings)
+        set_value("ALWAYS_ON_TOP", False, settings)
 
         # The last cv2 capture source index. This is an imperfect way to
         # remember the last video source used, since the indexes can reference
         # different sources at different times, but it's the best I can do in a
         # cross-platform environment
-        set_value("LAST_CAPTURE_SOURCE_INDEX", 0, settings=settings)
+        set_value("LAST_CAPTURE_SOURCE_INDEX", 0, settings)
 
         # Whether the program should try to open video on startup, or wait for
         # the user to press "reconnect video"
-        set_value("START_WITH_VIDEO", False, settings=settings)
+        set_value("START_WITH_VIDEO", False, settings)
 
         # Whether the minimal view should be showing
-        set_value("SHOW_MIN_VIEW", False, settings=settings)
+        set_value("SHOW_MIN_VIEW", False, settings)
 
         # Whether global hotkeys are enabled (default) or only local hotkeys
-        set_value("GLOBAL_HOTKEYS_ENABLED", True, settings=settings)
+        set_value("GLOBAL_HOTKEYS_ENABLED", True, settings)
 
         # Whether program checks for updates on launch
-        set_value("CHECK_FOR_UPDATES", True, settings=settings)
+        set_value("CHECK_FOR_UPDATES", True, settings)
 
     # Make sure image dir exists and is within the user's home dir
     # (This limits i/o to user-controlled areas)
-    last_image_dir = get_str("LAST_IMAGE_DIR", settings=settings)
+    last_image_dir = get_str("LAST_IMAGE_DIR", settings)
     if not last_image_dir.startswith(home_dir) or not Path(last_image_dir).is_dir():
-        set_value("LAST_IMAGE_DIR", home_dir, settings=settings)
+        set_value("LAST_IMAGE_DIR", home_dir, settings)
 
     # Always start in full view if video doesn't come on automatically
-    if not get_bool("START_WITH_VIDEO", settings=settings):
-        set_value("SHOW_MIN_VIEW", False, settings=settings)
+    if not get_bool("START_WITH_VIDEO", settings):
+        set_value("SHOW_MIN_VIEW", False, settings)
+
+    # Remember last used version number (to unset hotkeys if upgrading)
+    set_value("LAST_VERSION", VERSION_NUMBER, settings)
 
     # Set correct video, split image width and height relative to aspect ratio
-    aspect_ratio = get_str("ASPECT_RATIO", settings=settings)
+    aspect_ratio = get_str("ASPECT_RATIO", settings)
     if aspect_ratio == "4:3 (480x360)":
-        set_value("FRAME_WIDTH", 480, settings=settings)
-        set_value("FRAME_HEIGHT", 360, settings=settings)
+        set_value("FRAME_WIDTH", 480, settings)
+        set_value("FRAME_HEIGHT", 360, settings)
     elif aspect_ratio == "4:3 (320x240)":
-        set_value("FRAME_WIDTH", 320, settings=settings)
-        set_value("FRAME_HEIGHT", 240, settings=settings)
+        set_value("FRAME_WIDTH", 320, settings)
+        set_value("FRAME_HEIGHT", 240, settings)
     elif aspect_ratio == "16:9 (512x288)":
-        set_value("FRAME_WIDTH", 512, settings=settings)
-        set_value("FRAME_HEIGHT", 288, settings=settings)
+        set_value("FRAME_WIDTH", 512, settings)
+        set_value("FRAME_HEIGHT", 288, settings)
     elif aspect_ratio == "16:9 (432x243)":
-        set_value("FRAME_WIDTH", 432, settings=settings)
-        set_value("FRAME_HEIGHT", 243, settings=settings)
+        set_value("FRAME_WIDTH", 432, settings)
+        set_value("FRAME_HEIGHT", 243, settings)
+
+
+def version_ge(version1: str, version2: str) -> bool:
+    """Check whether version1 equal to or more recent than version2.
+
+    Versions are in format x.x.x or vx.x.x, where x is a nonnegative integer.
+
+    Args:
+        version1 (str): The first version number.
+        version2 (str): The second version number.
+
+    Returns:
+        bool: True if version1 is equal to or more recent than version2.
+    """
+
+    version1_numbers = version1.replace("v", "").split(".")
+    version2_numbers = version2.replace("v", "").split(".")
+
+    for i in range(3):
+        if version1_numbers[i] > version2_numbers[i]:
+            return True
+        if version1_numbers[i] < version2_numbers[i]:
+            return False
+
+    return True
+
+
+def unset_hotkey_bindings() -> None:
+    """Unset all hotkey bindings."""
+    # Text values
+    set_value("SPLIT_HOTKEY_NAME", "", settings)
+    set_value("RESET_HOTKEY_NAME", "", settings)
+    set_value("PAUSE_HOTKEY_NAME", "", settings)
+    set_value("UNDO_HOTKEY_NAME", "", settings)
+    set_value("SKIP_HOTKEY_NAME", "", settings)
+    set_value("PREV_HOTKEY_NAME", "", settings)
+    set_value("NEXT_HOTKEY_NAME", "", settings)
+    set_value("SCREENSHOT_HOTKEY_NAME", "", settings)
+    set_value("TOGGLE_HOTKEYS_HOTKEY_NAME", "", settings)
+
+    # Key IDs
+    set_value("SPLIT_HOTKEY_CODE", "", settings)
+    set_value("RESET_HOTKEY_CODE", "", settings)
+    set_value("PAUSE_HOTKEY_CODE", "", settings)
+    set_value("UNDO_HOTKEY_CODE", "", settings)
+    set_value("SKIP_HOTKEY_CODE", "", settings)
+    set_value("PREV_HOTKEY_CODE", "", settings)
+    set_value("NEXT_HOTKEY_CODE", "", settings)
+    set_value("SCREENSHOT_HOTKEY_CODE", "", settings)
+    set_value("TOGGLE_HOTKEYS_HOTKEY_CODE", "", settings)
 
 
 def get_latest_version() -> str:

--- a/src/settings.py
+++ b/src/settings.py
@@ -189,7 +189,7 @@ def set_defaults() -> None:
         set_value("SKIP_HOTKEY_NAME", "")
 
         # The text value of the previous split hotkey
-        set_value("PREVIOUS_HOTKEY_NAME", "")
+        set_value("PREV_HOTKEY_NAME", "")
 
         # The text value of the next split hotkey
         set_value("NEXT_HOTKEY_NAME", "")
@@ -216,7 +216,7 @@ def set_defaults() -> None:
         set_value("SKIP_HOTKEY_CODE", "")
 
         # The pynput.keyboard.Key.vk value of the previous split hotkey
-        set_value("PREVIOUS_HOTKEY_CODE", "")
+        set_value("PREV_HOTKEY_CODE", "")
 
         # The pynput.keyboard.Key.vk value of the next split hotkey
         set_value("NEXT_HOTKEY_CODE", "")

--- a/src/settings.py
+++ b/src/settings.py
@@ -43,7 +43,7 @@ COMPARISON_FRAME_WIDTH = 320
 COMPARISON_FRAME_HEIGHT = 240
 
 # Pilgrim Autosplitter's current version number
-VERSION_NUMBER = "v1.0.6"
+VERSION_NUMBER = "v1.0.7"
 
 # The URL of Pilgrim Autosplitter's GitHub repo
 REPO_URL = "https://github.com/pilgrimtabby/pilgrim-autosplitter/"

--- a/src/settings.py
+++ b/src/settings.py
@@ -26,8 +26,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-"""Persist and reference user settings and key values.
-"""
+"""Persist and reference user settings and key values."""
 
 
 import os
@@ -64,7 +63,7 @@ MAX_LOOPS_AND_WAIT = 99999
 MAX_THRESHOLD = 1
 
 
-def get_str(key: str) -> str:
+def get_str(key: str, settings: QSettings = settings) -> str:
     """Return a str from settings, regardless of the stored value's type.
 
     Args:
@@ -76,7 +75,7 @@ def get_str(key: str) -> str:
     return str(settings.value(key))
 
 
-def get_bool(key: str) -> bool:
+def get_bool(key: str, settings: QSettings = settings) -> bool:
     """Return a bool from settings, regardless of the stored value's type.
 
     Args:
@@ -91,7 +90,7 @@ def get_bool(key: str) -> bool:
         return False
 
 
-def get_int(key: str) -> int:
+def get_int(key: str, settings: QSettings = settings) -> int:
     """Return an int from settings, regardless of the stored value's type.
 
     This should only be used on settings for which is_digit would return True,
@@ -106,7 +105,7 @@ def get_int(key: str) -> int:
     return int(settings.value(key))
 
 
-def get_float(key: str) -> float:
+def get_float(key: str, settings: QSettings = settings) -> float:
     """Return a float from settings, regardless of the stored value's type.
 
     This should only be used to retrieve settings for which float(foo) would
@@ -121,7 +120,7 @@ def get_float(key: str) -> float:
     return float(settings.value(key))
 
 
-def set_value(key: str, value: any) -> None:
+def set_value(key: str, value: any, settings: QSettings = settings) -> None:
     """Persist a setting as a str, regardless of the value's type.
 
     Strings are preferred because QSettings doesn't remember types on all
@@ -134,7 +133,7 @@ def set_value(key: str, value: any) -> None:
     settings.setValue(key, str(value))
 
 
-def set_defaults() -> None:
+def set_defaults(settings: QSettings = settings) -> None:
     """Ensure that settings values make sense before they are used.
 
     Populates settings with default values if they have not yet been set.
@@ -147,142 +146,138 @@ def set_defaults() -> None:
     Makes sure that the correct aspect ratio is shown.
     """
     home_dir = get_home_dir()
-    if not get_bool("SETTINGS_SET"):
+    if not get_bool("SETTINGS_SET", settings=settings):
         # Indicate whether default settings have been populated
-        set_value("SETTINGS_SET", True)
+        set_value("SETTINGS_SET", True, settings=settings)
 
         # The default minimum match percent needed to force a split action
-        set_value("DEFAULT_THRESHOLD", 0.90)
+        set_value("DEFAULT_THRESHOLD", 0.90, settings=settings)
 
         # The default delay (seconds) before a split
-        set_value("DEFAULT_DELAY", 0.0)
+        set_value("DEFAULT_DELAY", 0.0, settings=settings)
 
         # The default pause (seconds) after a split
-        set_value("DEFAULT_PAUSE", 1.0)
+        set_value("DEFAULT_PAUSE", 1.0, settings=settings)
 
         # The FPS used by splitter and ui_controller
-        set_value("FPS", 30)
+        set_value("FPS", 30, settings=settings)
 
         # The location of split images
-        set_value("LAST_IMAGE_DIR", home_dir)
+        set_value("LAST_IMAGE_DIR", home_dir, settings=settings)
 
         # Determine whether screenshots should be opened using the machine's
         # default image viewer after capture
-        set_value("OPEN_SCREENSHOT_ON_CAPTURE", False)
+        set_value("OPEN_SCREENSHOT_ON_CAPTURE", False, settings=settings)
 
         # The number of decimal places shown when displaying match percents
-        set_value("MATCH_PERCENT_DECIMALS", 0)
+        set_value("MATCH_PERCENT_DECIMALS", 0, settings=settings)
 
         # The text value of the split hotkey
-        set_value("SPLIT_HOTKEY_NAME", "")
+        set_value("SPLIT_HOTKEY_NAME", "", settings=settings)
 
         # The text value of the reset hotkey
-        set_value("RESET_HOTKEY_NAME", "")
+        set_value("RESET_HOTKEY_NAME", "", settings=settings)
 
         # The text value of the pause hotkey
-        set_value("PAUSE_HOTKEY_NAME", "")
+        set_value("PAUSE_HOTKEY_NAME", "", settings=settings)
 
         # The text value of the undo hotkey
-        set_value("UNDO_HOTKEY_NAME", "")
+        set_value("UNDO_HOTKEY_NAME", "", settings=settings)
 
         # The text value of the skip split hotkey
-        set_value("SKIP_HOTKEY_NAME", "")
+        set_value("SKIP_HOTKEY_NAME", "", settings=settings)
 
         # The text value of the previous split hotkey
-        set_value("PREV_HOTKEY_NAME", "")
+        set_value("PREV_HOTKEY_NAME", "", settings=settings)
 
         # The text value of the next split hotkey
-        set_value("NEXT_HOTKEY_NAME", "")
+        set_value("NEXT_HOTKEY_NAME", "", settings=settings)
 
         # The text value of the screenshot hotkey
-        set_value("SCREENSHOT_HOTKEY_NAME", "")
+        set_value("SCREENSHOT_HOTKEY_NAME", "", settings=settings)
 
         # The text value of the toggle global hotkeys hotkey
-        set_value("TOGGLE_HOTKEYS_HOTKEY_NAME", "")
+        set_value("TOGGLE_HOTKEYS_HOTKEY_NAME", "", settings=settings)
 
         # The pynput.keyboard.Key.vk value of the split hotkey
         set_value("SPLIT_HOTKEY_CODE", "")
 
         # The pynput.keyboard.Key.vk value of the reset hotkey
-        set_value("RESET_HOTKEY_CODE", "")
+        set_value("RESET_HOTKEY_CODE", "", settings=settings)
 
         # The pynput.keyboard.Key.vk value of the pause hotkey
-        set_value("PAUSE_HOTKEY_CODE", "")
+        set_value("PAUSE_HOTKEY_CODE", "", settings=settings)
 
         # The pynput.keyboard.Key.vk value of the undo split hotkey
-        set_value("UNDO_HOTKEY_CODE", "")
+        set_value("UNDO_HOTKEY_CODE", "", settings=settings)
 
         # The pynput.keyboard.Key.vk value of the skip split hotkey
-        set_value("SKIP_HOTKEY_CODE", "")
+        set_value("SKIP_HOTKEY_CODE", "", settings=settings)
 
         # The pynput.keyboard.Key.vk value of the previous split hotkey
-        set_value("PREV_HOTKEY_CODE", "")
+        set_value("PREV_HOTKEY_CODE", "", settings=settings)
 
         # The pynput.keyboard.Key.vk value of the next split hotkey
-        set_value("NEXT_HOTKEY_CODE", "")
+        set_value("NEXT_HOTKEY_CODE", "", settings=settings)
 
         # The pynput.keyboard.Key.vk value of the screenshot hotkey
-        set_value("SCREENSHOT_HOTKEY_CODE", "")
+        set_value("SCREENSHOT_HOTKEY_CODE", "", settings=settings)
 
         # The pynput.keyboard.Key.vk value of the toggle global hotkeys hotkey
-        set_value("TOGGLE_HOTKEYS_HOTKEY_CODE", "")
+        set_value("TOGGLE_HOTKEYS_HOTKEY_CODE", "", settings=settings)
 
         # The UI theme
-        set_value("THEME", "dark")
+        set_value("THEME", "dark", settings=settings)
 
         # The aspect ratio
-        set_value("ASPECT_RATIO", "4:3 (480x360)")
+        set_value("ASPECT_RATIO", "4:3 (480x360)", settings=settings)
 
         # Always on top value
-        set_value("ALWAYS_ON_TOP", False)
+        set_value("ALWAYS_ON_TOP", False, settings=settings)
 
         # The last cv2 capture source index. This is an imperfect way to
         # remember the last video source used, since the indexes can reference
         # different sources at different times, but it's the best I can do in a
         # cross-platform environment
-        set_value("LAST_CAPTURE_SOURCE_INDEX", 0)
+        set_value("LAST_CAPTURE_SOURCE_INDEX", 0, settings=settings)
 
         # Whether the program should try to open video on startup, or wait for
         # the user to press "reconnect video"
-        set_value("START_WITH_VIDEO", False)
+        set_value("START_WITH_VIDEO", False, settings=settings)
 
         # Whether the minimal view should be showing
-        set_value("SHOW_MIN_VIEW", False)
+        set_value("SHOW_MIN_VIEW", False, settings=settings)
 
         # Whether global hotkeys are enabled (default) or only local hotkeys
-        set_value("GLOBAL_HOTKEYS_ENABLED", True)
+        set_value("GLOBAL_HOTKEYS_ENABLED", True, settings=settings)
 
         # Whether program checks for updates on launch
-        set_value("CHECK_FOR_UPDATES", True)
+        set_value("CHECK_FOR_UPDATES", True, settings=settings)
 
     # Make sure image dir exists and is within the user's home dir
     # (This limits i/o to user-controlled areas)
-    last_image_dir = get_str("LAST_IMAGE_DIR")
+    last_image_dir = get_str("LAST_IMAGE_DIR", settings=settings)
     if not last_image_dir.startswith(home_dir) or not Path(last_image_dir).is_dir():
-        set_value("LAST_IMAGE_DIR", home_dir)
+        set_value("LAST_IMAGE_DIR", home_dir, settings=settings)
 
     # Always start in full view if video doesn't come on automatically
-    if not get_bool("START_WITH_VIDEO"):
-        set_value("SHOW_MIN_VIEW", False)
+    if not get_bool("START_WITH_VIDEO", settings=settings):
+        set_value("SHOW_MIN_VIEW", False, settings=settings)
 
     # Set correct video, split image width and height relative to aspect ratio
-    aspect_ratio = get_str("ASPECT_RATIO")
+    aspect_ratio = get_str("ASPECT_RATIO", settings=settings)
     if aspect_ratio == "4:3 (480x360)":
-        set_value("ASPECT_RATIO", "4:3 (480x360)")
-        set_value("FRAME_WIDTH", 480)
-        set_value("FRAME_HEIGHT", 360)
+        set_value("FRAME_WIDTH", 480, settings=settings)
+        set_value("FRAME_HEIGHT", 360, settings=settings)
     elif aspect_ratio == "4:3 (320x240)":
-        set_value("ASPECT_RATIO", "4:3 (320x240)")
-        set_value("FRAME_WIDTH", 320)
-        set_value("FRAME_HEIGHT", 240)
+        set_value("FRAME_WIDTH", 320, settings=settings)
+        set_value("FRAME_HEIGHT", 240, settings=settings)
     elif aspect_ratio == "16:9 (512x288)":
-        set_value("ASPECT_RATIO", "16:9 (512x288)")
-        set_value("FRAME_WIDTH", 512)
-        set_value("FRAME_HEIGHT", 288)
+        set_value("FRAME_WIDTH", 512, settings=settings)
+        set_value("FRAME_HEIGHT", 288, settings=settings)
     elif aspect_ratio == "16:9 (432x243)":
-        set_value("ASPECT_RATIO", "16:9 (432x243)")
-        set_value("FRAME_WIDTH", 432)
-        set_value("FRAME_HEIGHT", 243)
+        set_value("FRAME_WIDTH", 432, settings=settings)
+        set_value("FRAME_HEIGHT", 243, settings=settings)
 
 
 def get_latest_version() -> str:

--- a/src/splitter/split_dir.py
+++ b/src/splitter/split_dir.py
@@ -36,7 +36,7 @@ import pathlib
 import re
 from multiprocessing import freeze_support
 from multiprocessing.dummy import Pool as ThreadPool
-from typing import Tuple
+from typing import List, Tuple
 
 import cv2
 import numpy
@@ -64,7 +64,7 @@ class SplitDir:
             exists.
         current_loop (int): The current split image's current loop, if it
             exists.
-        list (list[_SplitImage]): A list of all split images in the directory
+        List[List[_SplitImage]]: A list of all split images in the directory
             settings.get_str("LAST_IMAGE_DIR").
     """
 
@@ -158,7 +158,7 @@ class SplitDir:
     #             #
     ###############
 
-    def _get_split_images(self) -> list["_SplitImage"]:
+    def _get_split_images(self) -> List["_SplitImage"]:
         """Get a list of SplitImage objects from a directory.
 
         Currently supported image types include .png, .jpg, and .jpeg. Only
@@ -169,7 +169,7 @@ class SplitDir:
         lot when there are lots of images.
 
         Returns:
-            list[_SplitImage]: The list of SplitImage objects.
+            List[_SplitImage]: The list of SplitImage objects.
         """
 
         def get_split_image(index: int, path: str):

--- a/src/splitter/splitter.py
+++ b/src/splitter/splitter.py
@@ -212,7 +212,7 @@ class Splitter:
         current_match_percent = self.match_percent
         self.safe_exit_compare_thread()
         if current_match_percent is None and len(self.splits.list) > 0:
-                self.start_compare_thread()
+            self.start_compare_thread()
 
     ###################################
     #                                 #

--- a/src/splitter/splitter.py
+++ b/src/splitter/splitter.py
@@ -26,14 +26,12 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-"""Capture video and compare it to a template image.
-"""
-
+"""Capture video and compare it to a template image."""
 
 import platform
 import threading
 import time
-from typing import Tuple
+from typing import Optional, Tuple
 
 import cv2
 import numpy
@@ -170,7 +168,7 @@ class Splitter:
             self._compare_thread.join()
         self.suspended = True
 
-    def set_next_capture_index(self) -> None:
+    def set_next_capture_index(self) -> bool:
         """Try to find the next valid cv2 capture index, if it exists.
 
         cv2 capture indexes can be separated by invalid indexes (for example, 0
@@ -178,6 +176,9 @@ class Splitter:
         method will try 3 invalid indexes before returning to index 0.
 
         Saves the new index to settings, has no return value.
+
+        Returns:
+            bool: True if a new source was found.
         """
         source = settings.get_int("LAST_CAPTURE_SOURCE_INDEX") + 1
         found_valid_source = False
@@ -199,18 +200,19 @@ class Splitter:
             source = 0  # Give up, go back to first possible index
         settings.set_value("LAST_CAPTURE_SOURCE_INDEX", source)
 
+        return found_valid_source
+
     def toggle_suspended(self) -> None:
-        """Stop _compare_thread if it's running; else, start it if possible.
+        """Stop _compare_thread, then start it if the splitter was suspended
+        and there are splits.
 
         Use self.match_percent, since it will never be None if compare_thread
-        is alive.
+        is alive AND not suspended, which is the condition we're looking for.
         """
-        if self.match_percent is None:
-            self.safe_exit_compare_thread()
-            if len(self.splits.list) > 0:
+        current_match_percent = self.match_percent
+        self.safe_exit_compare_thread()
+        if current_match_percent is None and len(self.splits.list) > 0:
                 self.start_compare_thread()
-        else:
-            self.safe_exit_compare_thread()
 
     ###################################
     #                                 #
@@ -225,6 +227,7 @@ class Splitter:
         safely exited before calling this method.
         """
         self._cap = self._open_capture()
+        self._capture_max_fps = self._get_max_fps(self._cap)
         self.capture_thread = threading.Thread(target=self._capture)
         self._capture_thread_finished = False
         self.capture_thread.daemon = True
@@ -240,12 +243,6 @@ class Splitter:
         forces the capture source to choose the next-closest value, which in
         some cases is quite a lot smaller than the default. This saves CPU.
 
-        Set self._capture_max_fps to the capture's maximum FPS on platforms
-        where this is supported. This is done to prevent unnecessary
-        comparisons from being generated in _compare due to a mismatch between
-        the user's selected framerate and a capture-imposed cap which is lower.
-        This also saves CPU.
-
         Returns:
             cv2.VideoCapture: The initialized and configured VideoCapture.
         """
@@ -260,19 +257,35 @@ class Splitter:
         cap.set(cv2.CAP_PROP_BUFFERSIZE, 1)
         cap.set(cv2.CAP_PROP_FRAME_WIDTH, COMPARISON_FRAME_WIDTH)
         cap.set(cv2.CAP_PROP_FRAME_HEIGHT, COMPARISON_FRAME_HEIGHT)
-        try:
-            capture_max_fps = cap.get(cv2.CAP_PROP_FPS)
-            if capture_max_fps == 0:
-                self._capture_max_fps = 60
-            else:
-                self._capture_max_fps = capture_max_fps
-        except cv2.error:
-            self._capture_max_fps = 60
         return cap
+
+    def _get_max_fps(self, cap: cv2.VideoCapture) -> int:
+        """Get the max FPS of a capture source.
+
+        Set self._capture_max_fps to the capture's maximum FPS on platforms
+        where this is supported. This is done to prevent unnecessary
+        comparisons from being generated in _compare due to a mismatch between
+        the user's selected framerate and a capture-imposed cap which is lower.
+        This also saves CPU.
+
+        Args:
+            cap (cv2.VideoCapture): The capture source to check.
+
+        Returns:
+            int: The max frames per second.
+        """
+        try:
+            max_fps = cap.get(cv2.CAP_PROP_FPS)
+            if max_fps == 0:
+                max_fps = 60
+        except cv2.error:
+            max_fps = 60
+
+        return max_fps
 
     def _capture(self) -> None:
         """Read frames from a capture source, resize them, and expose them to
-        _compare and ui_controller.
+        _compare and ui_controller in a loop.
 
         self.comparison_frame should always be 320x240. This helps with results
         consistency when matching split images; it also saves a lot of time and
@@ -292,20 +305,17 @@ class Splitter:
         which makes it a good choice for image matching.
 
         This method continues indefinitely until self._capture_thread_finished
-        is set.
+        is set to True.
         """
         start_time = time.perf_counter()
         while not self._capture_thread_finished:
 
             # We don't need to wait if we are hitting the max capture fps,
             # since cap.read() blocks until the next frame is available anyway.
-            # So we only do this if we are targeting a framerate that is lower
-            # than the max fps
+            # So we only wait on the interval if we are targeting a framerate
+            # that is lower than the max fps.
             if self.target_fps < self._capture_max_fps:
-                current_time = time.perf_counter()
-                if current_time - start_time < self._interval:
-                    time.sleep(self._interval - (current_time - start_time))
-                start_time = time.perf_counter()
+                start_time = self._wait_for_interval(start_time)
 
             frame = self._cap.read()[1]
             if frame is None:  # Video feed is down, kill the thread
@@ -355,7 +365,7 @@ class Splitter:
         # Kill comparer if capture goes down
         self.safe_exit_compare_thread()
 
-    def _frame_to_pixmap(self, frame: numpy.ndarray) -> QPixmap:
+    def _frame_to_pixmap(self, frame: Optional[numpy.ndarray]) -> QPixmap:
         """Generate a QPixmap instance from a 3-channel image stored as a numpy
         array.
 
@@ -372,6 +382,20 @@ class Splitter:
         # Use Format_BGR888 because images generated with cv2 are in BGR format
         frame_img = QImage(frame, frame.shape[1], frame.shape[0], QImage.Format_BGR888)
         return QPixmap.fromImage(frame_img)
+
+    def _wait_for_interval(self, start_time: float):
+        """Sleep until self._interval seconds has passed since start_time.
+
+        Args:
+            start_time (float): The starting time.
+
+        Returns:
+            float: The current time after sleeping.
+        """
+        current_time = time.perf_counter()
+        if current_time - start_time < self._interval:
+            time.sleep(self._interval - (current_time - start_time))
+        return time.perf_counter()
 
     ###################################
     #                                 #
@@ -423,10 +447,7 @@ class Splitter:
         start_time = frame_counter_start_time = time.perf_counter()
 
         while not self._compare_thread_finished:
-            current_time = time.perf_counter()
-            if current_time - start_time < self._interval:
-                time.sleep(self._interval - (current_time - start_time))
-            start_time = time.perf_counter()
+            start_time = self._wait_for_interval(start_time)
 
             # Update self._interval to better track target framerate
             frames_this_second, frame_counter_start_time = self._update_fps_factor(

--- a/src/ui/ui_controller.py
+++ b/src/ui/ui_controller.py
@@ -37,6 +37,7 @@ import os
 import platform
 import subprocess
 import time
+from typing import Optional, Union
 import webbrowser
 from pathlib import Path
 from threading import Thread
@@ -1602,7 +1603,9 @@ class UIController:
         self._react_to_hotkey_flags()
         self._react_to_split_flags()
 
-    def _handle_key_press(self, key) -> None:
+    def _handle_key_press(
+        self, key: Union["pynput.keyboard.key", "keyboard.KeyboardEvent"]
+    ) -> None:
         """Process key presses, setting flags if the key is a hotkey.
 
         Called each time any key is pressed, whether or not the program is in
@@ -1863,7 +1866,7 @@ class UIController:
             subprocess.Popen([caffeinate_path, "-d", "-t", "1"])
             time.sleep(self._wake_interval)
 
-    def _get_exec_path(self, name: str) -> str | None:
+    def _get_exec_path(self, name: str) -> Optional[str]:
         """Return the path to an executable file, if it exists.
 
         Args:

--- a/src/ui/ui_controller.py
+++ b/src/ui/ui_controller.py
@@ -617,13 +617,12 @@ class UIController:
                 value = float(spinbox.value()) / 100
             else:
                 value = spinbox.value()
+            settings.set_value(setting_string, value)
 
             # Send new FPS value to controller and splitter
             if spinbox == self._settings_window.fps_spinbox:
                 self._poller.setInterval(self._get_interval())
                 self._splitter.target_fps = value
-
-            settings.set_value(setting_string, value)
 
         self._splitter.splits.set_default_threshold()
         self._splitter.splits.set_default_delay()

--- a/src/ui/ui_keyboard_controller.py
+++ b/src/ui/ui_keyboard_controller.py
@@ -31,6 +31,7 @@
 
 
 import platform
+
 if platform.system() == "Windows" or platform.system() == "Darwin":
     # Don't import the whole pynput library since that takes a while
     from pynput import keyboard as pynput_keyboard
@@ -47,14 +48,14 @@ class UIKeyboardController:
     to meet the current needs of Pilgrim Autosplitter. It provides a layer of
     abstraction to simplify development and maintanence in ui_controller.py.
     """
+
     def __init__(self) -> None:
-        """Initialize the keyboard controller (required for pynput backend).
-        """
+        """Initialize the keyboard controller (required for pynput backend)."""
         if platform.system() == "Windows" or platform.system() == "Darwin":
             self._controller = pynput_keyboard.Controller()
         else:
             self._controller = None
-    
+
     def start_listener(self, on_press, on_release) -> None:
         """Start a keyboard listener.
 

--- a/src/ui/ui_keyboard_controller.py
+++ b/src/ui/ui_keyboard_controller.py
@@ -1,0 +1,140 @@
+# Copyright (c) 2024 pilgrim_tabby
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Wrapper for separate keyboard manip libraries to support cross-platform dev.
+"""
+
+
+import platform
+if platform.system() == "Windows" or platform.system() == "Darwin":
+    # Don't import the whole pynput library since that takes a while
+    from pynput import keyboard as pynput_keyboard
+else:
+    # Pynput doesn't work well on Linux, so use keyboard instead
+    import keyboard
+
+
+class UIKeyboardController:
+    """Basic frontend wrapper for controlling the keyboard cross-platform.
+
+    On Windows and MacOS, use pynput; on Linux, use keyboard. This wrapper
+    lacks many basic functionalities of both libraries because it was designed
+    to meet the current needs of Pilgrim Autosplitter. It provides a layer of
+    abstraction to simplify development and maintanence in ui_controller.py.
+    """
+    def __init__(self) -> None:
+        """Initialize the keyboard controller (required for pynput backend).
+        """
+        if platform.system() == "Windows" or platform.system() == "Darwin":
+            self._controller = pynput_keyboard.Controller()
+        else:
+            self._controller = None
+    
+    def start_listener(self, on_press, on_release) -> None:
+        """Start a keyboard listener.
+
+        This method doesn't return the listener, because it's not required
+        (yet) for this project, but it can/should be modified to do so if it
+        becomes necessary (only possible w/ pynput).
+
+        Args:
+            on_press (function | None): Function to be executed on key down. If
+                None, call _do_nothing (pass).
+            on_release (function | None): Function to be executed on key up. If
+                None, call _do_nothing (pass).
+        """
+        if on_press is None:
+            on_press = self._do_nothing
+        if on_release is None:
+            on_release = self._do_nothing
+
+        if platform.system() == "Windows" or platform.system() == "Darwin":
+            keyboard_listener = pynput_keyboard.Listener(
+                on_press=on_press, on_release=on_release
+            )
+            keyboard_listener.start()
+        else:
+            keyboard.on_press(on_press)
+            keyboard.on_release(on_release)
+
+    def press_and_release(self, key_code: str) -> None:
+        """Press and release a hotkey.
+
+        Args:
+            key_code (str): A string representation of a pynput.keyboard.Key.vk
+                value (or a keyboard.KeyboardEvent.name value on Linux).
+                Passed as a string because this project uses QSettings, which
+                converts all types to strings on some backends.
+        """
+        if platform.system() == "Windows" or platform.system() == "Darwin":
+            key_code = int(key_code)
+            key = pynput_keyboard.KeyCode(vk=key_code)
+            self._controller.press(key)
+            self._controller.release(key)
+        else:
+            keyboard.send(key_code)
+
+    def release(self, key) -> None:
+        """Release a key.
+
+        Args:
+            key (str): A string representation of a key. This method WILL FAIL
+                when using pynput if the key is not an alphanumeric key (e.g.
+                passing "f12" or "enter" will not work).
+        """
+        if platform.system() == "Windows" or platform.system() == "Darwin":
+            self._controller.release(key)
+        else:
+            keyboard.release(key)
+
+    def parse_key_info(self, key) -> tuple[str, str | int]:
+        """Return a key's string name and its internal integer value.
+
+        Args:
+            key: A wrapper whose structure and contents depend on the backend.
+                With pynput (Windows / MacOS), it's a pynput.keyboard.Key; with
+                keyboard (Linux) it's a keyboard.KeyboardEvent).
+
+        Returns:
+            key_name (str): Name of the key in a human-readable format.
+            key_code (str | int): With pynput, it's a "vk" code, or an integer
+                representation of a key that varies by machine. With keybaord,
+                it's the same as key_name.
+        """
+        if platform.system() == "Windows" or platform.system() == "Darwin":
+            try:
+                return key.char, key.vk
+            # Thrown when the key isn't an alphanumeric key
+            except AttributeError:
+                return str(key).replace("Key.", ""), key.value.vk
+        else:
+            return key.name, key.name
+
+    def _do_nothing(self, *args, **kwargs) -> None:
+        """Dummy method for when you don't want anything to happen."""
+        pass

--- a/src/ui/ui_keyboard_controller.py
+++ b/src/ui/ui_keyboard_controller.py
@@ -31,6 +31,7 @@
 
 
 import platform
+from typing import Callable, Optional, Tuple, Union
 
 if platform.system() == "Windows" or platform.system() == "Darwin":
     # Don't import the whole pynput library since that takes a while
@@ -56,7 +57,11 @@ class UIKeyboardController:
         else:
             self._controller = None
 
-    def start_listener(self, on_press, on_release) -> None:
+    def start_listener(
+        self,
+        on_press: Optional[Callable[..., None]],
+        on_release: Optional[Callable[..., None]],
+    ) -> None:
         """Start a keyboard listener.
 
         This method doesn't return the listener, because it's not required
@@ -64,9 +69,9 @@ class UIKeyboardController:
         becomes necessary (only possible w/ pynput).
 
         Args:
-            on_press (function | None): Function to be executed on key down. If
+            on_press (callable | None): Function to be executed on key down. If
                 None, call _do_nothing (pass).
-            on_release (function | None): Function to be executed on key up. If
+            on_release (callable | None): Function to be executed on key up. If
                 None, call _do_nothing (pass).
         """
         if on_press is None:
@@ -100,7 +105,9 @@ class UIKeyboardController:
         else:
             keyboard.send(key_code)
 
-    def release(self, key) -> None:
+    def release(
+        self, key: Union["pynput_keyboard.key", "keyboard.KeyboardEvent"]
+    ) -> None:
         """Release a key.
 
         Args:
@@ -113,7 +120,9 @@ class UIKeyboardController:
         else:
             keyboard.release(key)
 
-    def parse_key_info(self, key) -> tuple[str, str | int]:
+    def parse_key_info(
+        self, key: Union["pynput_keyboard.key", "keyboard.KeyboardEvent"]
+    ) -> Tuple[str, Union[str, int]]:
         """Return a key's string name and its internal integer value.
 
         Args:

--- a/src/ui/ui_main_window.py
+++ b/src/ui/ui_main_window.py
@@ -32,6 +32,7 @@ should be provided in a controller class.
 
 
 import platform
+from typing import Optional
 
 from PyQt5.QtCore import QRect, Qt, pyqtSignal
 from PyQt5.QtGui import QMouseEvent
@@ -578,7 +579,7 @@ class ClickableLineEdit(QLineEdit):
 
     clicked = pyqtSignal()
 
-    def __init__(self, parent=None) -> None:
+    def __init__(self, parent: Optional[QWidget] = None) -> None:
         """Inherit from QLineEdit and set attributes to None.
 
         Args:
@@ -586,7 +587,7 @@ class ClickableLineEdit(QLineEdit):
         """
         QLineEdit.__init__(self, parent)
 
-    def mouseMoveEvent(self, a0: QMouseEvent | None) -> None:
+    def mouseMoveEvent(self, a0: Optional[QMouseEvent]) -> None:
         """Prevent the mouse moving from having any effect.
 
         I override this method specifically to prevent selecting text by
@@ -599,7 +600,7 @@ class ClickableLineEdit(QLineEdit):
         """
         pass
 
-    def mouseDoubleClickEvent(self, a0: QMouseEvent | None) -> None:
+    def mouseDoubleClickEvent(self, a0: Optional[QMouseEvent]) -> None:
         """Prevent a double click from having any effect.
 
         I override this method specifically to prevent double-clicking to

--- a/src/ui/ui_main_window.py
+++ b/src/ui/ui_main_window.py
@@ -550,7 +550,7 @@ class UIMainWindow(QMainWindow):
 
         if settings.get_bool("CHECK_FOR_UPDATES"):
             latest_version = settings.get_latest_version()
-            if latest_version != settings.VERSION_NUMBER:
+            if not settings.version_ge(settings.VERSION_NUMBER, latest_version):
                 # Yes, I call both show and open. If you just call show, the
                 # box doesn't always appear centered over the window (it's way
                 # off to the side). If you just call show, then bafflingly, the

--- a/src/ui/ui_settings_window.py
+++ b/src/ui/ui_settings_window.py
@@ -32,7 +32,7 @@ and should be provided in a controller class.
 
 
 import platform
-from typing import Union
+from typing import Optional, Union
 
 from PyQt5.QtCore import QEvent, QRect, Qt
 from PyQt5.QtGui import QColor
@@ -659,7 +659,7 @@ class UISettingsWindow(QDialog):
         self.save_button.setGeometry(QRect(459 + self._LEFT, 326 + self._TOP, 111, 31))
         self.save_button.setFocusPolicy(Qt.NoFocus)
 
-    def event(self, event) -> Union[bool, QWidget.event]:
+    def event(self, event: QWidget.event) -> Union[bool, QWidget.event]:
         """Allow the user to take focus off a widget by clicking somewhere
         else.
 
@@ -693,7 +693,7 @@ class KeyLineEdit(QLineEdit):
             depending on the backend used).
     """
 
-    def __init__(self, parent=None) -> None:
+    def __init__(self, parent: Optional[QWidget] = None) -> None:
         """Initialize a KeyLineEdit with a blank key_code value.
 
         Args:

--- a/src/ui/ui_settings_window.py
+++ b/src/ui/ui_settings_window.py
@@ -702,3 +702,19 @@ class KeyLineEdit(QLineEdit):
         """
         QLineEdit.__init__(self, parent)
         self.key_code = ""
+
+    def get_text_width(self) -> int:
+        """Get the current width in pixels of the current text.
+
+        Returns:
+            int: The width of the text.
+        """
+        return self.fontMetrics().boundingRect(self.text()).width()
+
+    def get_font_size(self) -> int:
+        """Shortcut method to get the current font size.
+
+        Returns:
+            int: The font size.
+        """
+        return self.fontInfo().pointSize()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,6 @@
+"""Add files in /src to PATH so they can be tested."""
+
+import sys
+
+
+sys.path.append("./src")

--- a/tests/test_pilgrim_autosplitter.py
+++ b/tests/test_pilgrim_autosplitter.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2024 pilgrim_tabby
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Test pilgrim_autosplitter.py."""
+
+from PyQt5.QtWidgets import QApplication
+
+from pilgrim_autosplitter import PilgrimAutosplitter
+from splitter.splitter import Splitter
+from ui.ui_controller import UIController
+
+
+def test_PilgrimAutosplitter():
+    app = PilgrimAutosplitter()
+    assert (
+        type(app.app) == QApplication
+        and type(app.splitter) == Splitter
+        and type(app.ui_controller) == UIController
+    )

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,239 @@
+# Copyright (c) 2024 pilgrim_tabby
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Test settings.py."""
+
+import pytest
+import requests
+from pathlib import Path
+from PyQt5.QtCore import QSettings
+
+import settings
+
+
+class TestURLs:
+    """Test whether defined URLs lead to live sites."""
+
+    def get_url_code(self, url: str):
+        return requests.head(url).status_code
+
+    def test_repo_url_live(self):
+        assert self.get_url_code(settings.REPO_URL) == 200
+
+    def test_user_manual_url_live(self):
+        assert self.get_url_code(settings.USER_MANUAL_URL) == 200
+
+
+class TestSettingsFunctionsWithDummySettings:
+    """Test functions in settings.py that rely on a "settings" var."""
+
+    @pytest.fixture(autouse=True)
+    def dummy_settings(self):
+        """Provide blank QSettings file for testing.
+
+        Yields:
+            QSettings: The blank QSettings file.
+        """
+        self.dummy_settings = QSettings("pilgrim_tabby", "pilgrim_autosplitter_test")
+        self.dummy_settings.clear()
+        yield self.dummy_settings
+        self.dummy_settings.clear()
+
+    # Testing set_value
+    def test_set_value_str(self):
+        settings.set_value("test", "hello world", settings=self.dummy_settings)
+        assert self.dummy_settings.value("test") == "hello world"
+
+    def test_set_value_int(self):
+        settings.set_value("test", 1337, settings=self.dummy_settings)
+        assert self.dummy_settings.value("test") == "1337"
+
+    def test_set_value_blank(self):
+        settings.set_value("test", "", settings=self.dummy_settings)
+        assert self.dummy_settings.value("test") == ""
+
+    # Testing get_str
+    def test_get_str_defined_val(self):
+        self.dummy_settings.setValue("test", "foo")
+        assert settings.get_str("test", settings=self.dummy_settings) == "foo"
+
+    def test_get_str_unset_val(self):
+        assert settings.get_str("test", settings=self.dummy_settings) == "None"
+
+    def test_get_str_blank_val(self):
+        self.dummy_settings.setValue("test", "")
+        assert settings.get_str("test", settings=self.dummy_settings) == ""
+
+    def test_get_str_from_int(self):
+        self.dummy_settings.setValue("test", 123)
+        assert settings.get_str("test", settings=self.dummy_settings) == "123"
+
+    # Testing get_bool
+    def test_get_bool_from_str_1(self):
+        self.dummy_settings.setValue("test", "True")
+        assert settings.get_bool("test", settings=self.dummy_settings) == True
+
+    def test_get_bool_from_str_2(self):
+        self.dummy_settings.setValue("test", "true")
+        assert settings.get_bool("test", settings=self.dummy_settings) == False
+
+    def test_get_bool_from_str_3(self):
+        self.dummy_settings.setValue("test", "False")
+        assert settings.get_bool("test", settings=self.dummy_settings) == False
+
+    def test_get_bool_from_random_val(self):
+        self.dummy_settings.setValue("test", 1.23456543)
+        assert settings.get_bool("test", settings=self.dummy_settings) == False
+
+    def test_get_bool_from_unset_val(self):
+        assert settings.get_bool("test", settings=self.dummy_settings) == False
+
+    def test_get_bool_from_blank_val(self):
+        self.dummy_settings.setValue("test", "")
+        assert settings.get_bool("test", settings=self.dummy_settings) == False
+
+    # Testing get_int
+    def test_get_int_from_non_int(self):
+        self.dummy_settings.setValue("test", "this will fail")
+        with pytest.raises(ValueError):
+            settings.get_int("test", settings=self.dummy_settings)
+
+    def test_get_int_from_blank_val(self):
+        self.dummy_settings.setValue("test", "")
+        with pytest.raises(ValueError):
+            settings.get_int("test", settings=self.dummy_settings)
+
+    def test_get_int_from_str_1(self):
+        self.dummy_settings.setValue("test", "33")
+        assert settings.get_int("test", settings=self.dummy_settings) == 33
+
+    def test_get_int_from_str_2(self):
+        self.dummy_settings.setValue("test", "-33")
+        assert settings.get_int("test", settings=self.dummy_settings) == -33
+
+    def test_get_int_from_int(self):
+        self.dummy_settings.setValue("test", -1)
+        assert settings.get_int("test", settings=self.dummy_settings) == -1
+
+    # Testing get_float
+    def test_get_float_from_str(self):
+        self.dummy_settings.setValue("test", "this will fail")
+        with pytest.raises(ValueError):
+            settings.get_float("test", settings=self.dummy_settings)
+
+    def test_get_float_from_blank_val(self):
+        self.dummy_settings.setValue("test", "")
+        with pytest.raises(ValueError):
+            settings.get_float("test", settings=self.dummy_settings)
+
+    def test_get_float_from_str(self):
+        self.dummy_settings.setValue("test", "-0")
+        assert settings.get_float("test", settings=self.dummy_settings) == 0
+
+    def test_get_float_from_int(self):
+        self.dummy_settings.setValue("test", 123)
+        assert settings.get_float("test", settings=self.dummy_settings) == 123
+
+    def test_get_float_from_float(self):
+        self.dummy_settings.setValue("test", 123.123123)
+        assert settings.get_float("test", settings=self.dummy_settings) == 123.123123
+
+    # Testing set_defaults
+    def test_set_defaults_runs_on_blank_settings(self):
+        settings.set_defaults(settings=self.dummy_settings)
+        assert settings.get_bool("SETTINGS_SET", settings=self.dummy_settings)
+
+    def test_set_defaults_turns_off_show_min_view(self):
+        settings.set_defaults(settings=self.dummy_settings)
+        orig_start_with_video = settings.get_bool(
+            "START_WITH_VIDEO", settings=self.dummy_settings
+        )
+        settings.set_value("SHOW_MIN_VIEW", True, settings=self.dummy_settings)
+        settings.set_defaults(settings=self.dummy_settings)
+        assert not orig_start_with_video and not settings.get_bool(
+            "SHOW_MIN_VIEW", settings=self.dummy_settings
+        )
+
+    def test_set_defaults_sets_correct_aspect_ratio_1(self):
+        settings.set_defaults(settings=self.dummy_settings)
+        settings.set_value(
+            "ASPECT_RATIO", "4:3 (480x360)", settings=self.dummy_settings
+        )
+        settings.set_defaults(settings=self.dummy_settings)
+        assert (
+            settings.get_int("FRAME_WIDTH", settings=self.dummy_settings) == 480
+            and settings.get_int("FRAME_HEIGHT", settings=self.dummy_settings) == 360
+        )
+
+    def test_set_defaults_sets_correct_aspect_ratio_2(self):
+        settings.set_defaults(settings=self.dummy_settings)
+        settings.set_value(
+            "ASPECT_RATIO", "4:3 (320x240)", settings=self.dummy_settings
+        )
+        settings.set_defaults(settings=self.dummy_settings)
+        assert (
+            settings.get_int("FRAME_WIDTH", settings=self.dummy_settings) == 320
+            and settings.get_int("FRAME_HEIGHT", settings=self.dummy_settings) == 240
+        )
+
+    def test_set_defaults_sets_correct_aspect_ratio_3(self):
+        settings.set_defaults(settings=self.dummy_settings)
+        settings.set_value(
+            "ASPECT_RATIO", "16:9 (512x288)", settings=self.dummy_settings
+        )
+        settings.set_defaults(settings=self.dummy_settings)
+        assert (
+            settings.get_int("FRAME_WIDTH", settings=self.dummy_settings) == 512
+            and settings.get_int("FRAME_HEIGHT", settings=self.dummy_settings) == 288
+        )
+
+    def test_set_defaults_sets_correct_aspect_ratio_4(self):
+        settings.set_defaults(settings=self.dummy_settings)
+        settings.set_value(
+            "ASPECT_RATIO", "16:9 (432x243)", settings=self.dummy_settings
+        )
+        settings.set_defaults(settings=self.dummy_settings)
+        assert (
+            settings.get_int("FRAME_WIDTH", settings=self.dummy_settings) == 432
+            and settings.get_int("FRAME_HEIGHT", settings=self.dummy_settings) == 243
+        )
+
+
+def test_get_latest_version():
+    latest_version = settings.get_latest_version()
+    version_numbers = latest_version.split(".")
+    assert (
+        len(version_numbers) == 3
+        and "v" in version_numbers[0]
+        and version_numbers[1].isdigit()
+        and version_numbers[2].isdigit()
+    )
+
+
+def test_get_home_dir_returns_real_path():
+    assert Path(settings.get_home_dir()).is_dir()

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -163,61 +163,61 @@ class TestSettingsFunctionsWithDummySettings:
         self.dummy_settings.setValue("test", 123.123123)
         assert settings.get_float("test", settings=self.dummy_settings) == 123.123123
 
-    # Testing set_defaults
-    def test_set_defaults_runs_on_blank_settings(self):
-        settings.set_defaults(settings=self.dummy_settings)
+    # Testing set_program_vals
+    def test_set_program_vals_runs_on_blank_settings(self):
+        settings.set_program_vals(settings=self.dummy_settings)
         assert settings.get_bool("SETTINGS_SET", settings=self.dummy_settings)
 
-    def test_set_defaults_turns_off_show_min_view(self):
-        settings.set_defaults(settings=self.dummy_settings)
+    def test_set_program_vals_turns_off_show_min_view(self):
+        settings.set_program_vals(settings=self.dummy_settings)
         orig_start_with_video = settings.get_bool(
             "START_WITH_VIDEO", settings=self.dummy_settings
         )
         settings.set_value("SHOW_MIN_VIEW", True, settings=self.dummy_settings)
-        settings.set_defaults(settings=self.dummy_settings)
+        settings.set_program_vals(settings=self.dummy_settings)
         assert not orig_start_with_video and not settings.get_bool(
             "SHOW_MIN_VIEW", settings=self.dummy_settings
         )
 
-    def test_set_defaults_sets_correct_aspect_ratio_1(self):
-        settings.set_defaults(settings=self.dummy_settings)
+    def test_set_program_vals_sets_correct_aspect_ratio_1(self):
+        settings.set_program_vals(settings=self.dummy_settings)
         settings.set_value(
             "ASPECT_RATIO", "4:3 (480x360)", settings=self.dummy_settings
         )
-        settings.set_defaults(settings=self.dummy_settings)
+        settings.set_program_vals(settings=self.dummy_settings)
         assert (
             settings.get_int("FRAME_WIDTH", settings=self.dummy_settings) == 480
             and settings.get_int("FRAME_HEIGHT", settings=self.dummy_settings) == 360
         )
 
-    def test_set_defaults_sets_correct_aspect_ratio_2(self):
-        settings.set_defaults(settings=self.dummy_settings)
+    def test_set_program_vals_sets_correct_aspect_ratio_2(self):
+        settings.set_program_vals(settings=self.dummy_settings)
         settings.set_value(
             "ASPECT_RATIO", "4:3 (320x240)", settings=self.dummy_settings
         )
-        settings.set_defaults(settings=self.dummy_settings)
+        settings.set_program_vals(settings=self.dummy_settings)
         assert (
             settings.get_int("FRAME_WIDTH", settings=self.dummy_settings) == 320
             and settings.get_int("FRAME_HEIGHT", settings=self.dummy_settings) == 240
         )
 
-    def test_set_defaults_sets_correct_aspect_ratio_3(self):
-        settings.set_defaults(settings=self.dummy_settings)
+    def test_set_program_vals_sets_correct_aspect_ratio_3(self):
+        settings.set_program_vals(settings=self.dummy_settings)
         settings.set_value(
             "ASPECT_RATIO", "16:9 (512x288)", settings=self.dummy_settings
         )
-        settings.set_defaults(settings=self.dummy_settings)
+        settings.set_program_vals(settings=self.dummy_settings)
         assert (
             settings.get_int("FRAME_WIDTH", settings=self.dummy_settings) == 512
             and settings.get_int("FRAME_HEIGHT", settings=self.dummy_settings) == 288
         )
 
-    def test_set_defaults_sets_correct_aspect_ratio_4(self):
-        settings.set_defaults(settings=self.dummy_settings)
+    def test_set_program_vals_sets_correct_aspect_ratio_4(self):
+        settings.set_program_vals(settings=self.dummy_settings)
         settings.set_value(
             "ASPECT_RATIO", "16:9 (432x243)", settings=self.dummy_settings
         )
-        settings.set_defaults(settings=self.dummy_settings)
+        settings.set_program_vals(settings=self.dummy_settings)
         assert (
             settings.get_int("FRAME_WIDTH", settings=self.dummy_settings) == 432
             and settings.get_int("FRAME_HEIGHT", settings=self.dummy_settings) == 243
@@ -237,3 +237,36 @@ def test_get_latest_version():
 
 def test_get_home_dir_returns_real_path():
     assert Path(settings.get_home_dir()).is_dir()
+
+
+# Testing version_ge
+def test_version_ge_1():
+    assert settings.version_ge("1.0.1", "1.0.0")
+
+
+def test_version_ge_2():
+    assert settings.version_ge("1.0.1", "1.0.1")
+
+
+def test_version_ge_3():
+    assert settings.version_ge("1.1.0", "1.0.1")
+
+
+def test_version_ge_4():
+    assert settings.version_ge("2.1.0", "1.0.1")
+
+
+def test_version_ge_5():
+    assert settings.version_ge("1.1.0", "1.0.0")
+
+
+def test_version_ge_6():
+    assert not settings.version_ge("1.1.0", "1.1.1")
+
+
+def test_version_ge_6():
+    assert settings.version_ge("1.2.0", "1.1.10")
+
+
+def test_version_ge_7():
+    assert settings.version_ge("1.0.0", "0.20000.999")

--- a/tests/test_splitter/__init__.py
+++ b/tests/test_splitter/__init__.py
@@ -1,0 +1,6 @@
+"""Add files in /src to PATH so they can be tested."""
+
+import sys
+
+
+sys.path.append("./src")

--- a/tests/test_splitter/test_splitter.py
+++ b/tests/test_splitter/test_splitter.py
@@ -1,0 +1,169 @@
+# Copyright (c) 2024 pilgrim_tabby
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Test splitter.py."""
+
+import time
+import cv2
+import pytest
+from PyQt5.QtWidgets import QApplication
+
+import settings
+from splitter.splitter import Splitter
+from splitter.split_dir import SplitDir
+
+
+class TestSplitter:
+    """Test Splitter methods using a dummy class instance."""
+
+    # Required for using QWidgets
+    dummy_app = QApplication([])
+
+    @pytest.fixture(autouse=True)
+    def dummy_splitter(self):
+        """Spin up dummy Splitter instance with no split images for testing.
+
+        Yields:
+            Splitter: The Splitter instance.
+        """
+        self.splitter = Splitter()
+        self.splitter.splits.list = []
+
+        yield self.splitter
+
+        self.splitter.safe_exit_all_threads()
+
+    def start_capture_and_compare(self):
+        test_img = "resources/icon-macos.png"
+        self.splitter.splits.list += [SplitDir._SplitImage(test_img)]
+        self.splitter.start()
+
+    def is_float_or_int(self, target: str):
+        arg_list = target.split(".")
+        for entry in arg_list:
+            if not entry.isdigit():
+                return False
+        return True
+
+    def test_start_no_splits(self):
+        self.splitter.start()
+        assert (
+            self.splitter.capture_thread.is_alive()
+            and not self.splitter._compare_thread.is_alive()
+        )
+
+    def test_start_with_splits(self):
+        self.start_capture_and_compare()
+        assert (
+            self.splitter.capture_thread.is_alive()
+            and self.splitter._compare_thread.is_alive()
+        )
+
+    def test_exit_all_threads(self):
+        self.start_capture_and_compare()
+
+        capture_thread_orig_status = self.splitter.capture_thread.is_alive()
+        compare_thread_orig_status = self.splitter._compare_thread.is_alive()
+        self.splitter.safe_exit_all_threads()
+
+        assert (
+            capture_thread_orig_status
+            and compare_thread_orig_status
+            and not self.splitter.capture_thread.is_alive()
+            and not self.splitter._compare_thread.is_alive()
+        )
+
+    def test_start_compare_thread(self):
+        self.splitter.start_compare_thread()
+        assert self.splitter._compare_thread.is_alive()
+
+    def test_safe_exit_compare_thread(self):
+        self.start_capture_and_compare()
+        compare_thread_orig_status = self.splitter._compare_thread.is_alive()
+        self.splitter.safe_exit_compare_thread()
+        assert (
+            compare_thread_orig_status and not self.splitter._compare_thread.is_alive()
+        )
+
+    def test_set_next_capture_index(self):
+        curr_index = settings.get_int("LAST_CAPTURE_SOURCE_INDEX")
+        found_new_source = self.splitter.set_next_capture_index()
+        new_index = settings.get_int("LAST_CAPTURE_SOURCE_INDEX")
+        assert curr_index != new_index or not found_new_source
+
+    def test_toggle_suspended_on(self):
+        self.start_capture_and_compare()
+        self.splitter.toggle_suspended()
+        assert not self.splitter._compare_thread.is_alive()
+
+    def test_toggle_suspended_off_with_split_image(self):
+        test_img = "resources/icon-macos.png"
+        self.splitter.splits.list += [SplitDir._SplitImage(test_img)]
+
+        self.splitter.toggle_suspended()
+        assert self.splitter._compare_thread.is_alive()
+
+    def test_toggle_suspended_off_during_split_delay(self):
+        pass
+
+    def test_toggle_suspended_off_during_split_suspend(self):
+        pass
+
+    def test_toggle_suspended_off_without_split_image(self):
+        self.splitter.toggle_suspended()
+        assert not self.splitter._compare_thread.is_alive()
+
+    def test_start_capture_thread(self):
+        capture_thread_orig_status = self.splitter.capture_thread.is_alive()
+        self.splitter._start_capture_thread()
+        assert (
+            not capture_thread_orig_status and self.splitter.capture_thread.is_alive()
+        )
+
+    def test_open_capture(self):
+        cap = self.splitter._open_capture()
+        assert type(cap) == cv2.VideoCapture
+
+    def test_get_max_fps(self):
+        cap = self.splitter._open_capture()
+        max_fps = self.splitter._get_max_fps(cap)
+        assert self.is_float_or_int(str(max_fps)) and max_fps >= 0
+
+    def test_capture(self):
+        pass
+
+    def test_frame_to_pixmap(self):
+        pass
+
+    def test_wait_for_interval(self):
+        start_time = time.perf_counter()
+        new_time = self.splitter._wait_for_interval(start_time)
+
+        assert (
+            pytest.approx(new_time - start_time, abs=0.005) == self.splitter._interval
+        )

--- a/tests/test_ui/__init__.py
+++ b/tests/test_ui/__init__.py
@@ -1,0 +1,6 @@
+"""Add files in /src to PATH so they can be tested."""
+
+import sys
+
+
+sys.path.append("./src")


### PR DESCRIPTION
This PR shifts the code handling keyboard listener/controller backends from ui_controller to a new module called ui_keyboard_controller. This is done to keep keyboard handling in ui_controller abstract, and makes it easier to handle the complexities of using two different backends depending on the platform.

In addition, this PR adds some unit tests for settings.py, splitter.py, and pilgrim_autosplitter.py. This whole project should have unit tests but I have limited time to devote to this right now, so it's not a priority.

It also fixes several bugs, most related to hotkey implementation:
- Hotkeys will no longer be bound to multiple keys when their key codes match (pynput only)
- Hotkeys can no longer be bound if they have a key code but no name (pynput) -- this prevents the user from thinking no key is bound when in reality there is one
- ui._poll is now called at the correct interval even after a settings change (whoops)
- Fix implementation issue that could cause segmentation fault occasionally when binding hotkeys

Other misc. changes/updates:
- Automatically resize the font if hotkey names are larger than the hotkey box
- On MacOS, make calls to caffeinate in separate thread to avoid bogging down main thread
- Typehints are now uniform in style and backwards compatible with Python 3.8+
- Some class attributes and methods have been renamed for brevity and readability
- Pytest added to requirements.txt and requirements-linux.txt
- pilgrim_autosplitter.py rewritten for clarity and neatness
- settings.py refactored to allow using different QSettings in functions for testing purposes
- Some methods in splitter.py refactored and/or split into multiple methods for testing purposes or for clarity